### PR TITLE
Add thirdparty c-blosc2 library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PhotoshopAPI/thirdparty/c-blosc2"]
+	path = thirdparty/c-blosc2
+	url = https://github.com/Blosc/c-blosc2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set (CMAKE_CXX_STANDARD 20)
 
 if(MSVC)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 # Enable Hot Reload for MSVC compilers if supported.
@@ -19,6 +20,9 @@ project ("PhotoshopAPIBuild")
 # Include sub-projects.
 add_subdirectory ("${CMAKE_SOURCE_DIR}/PhotoshopAPI")
 add_subdirectory ("${CMAKE_SOURCE_DIR}/PhotoshopTest")
+
+# Add thirdparty libraries
+add_subdirectory ("${CMAKE_SOURCE_DIR}/thirdparty/c-blosc2")
 
 # Set the test project (PhotoshopTest) as the default target
 add_custom_target(default_target ALL

--- a/PhotoshopAPI/CMakeLists.txt
+++ b/PhotoshopAPI/CMakeLists.txt
@@ -15,12 +15,13 @@ add_library (${LIB} STATIC
 	"${PROJECT_SOURCE_DIR}/src/Util/Struct/TaggedBlock.cpp"
 )
 
-if(MSVC)
-	target_compile_options(${LIB} PRIVATE "/MP")
-	target_compile_options(${LIB} PRIVATE /W4 /WX)
-else()
-	target_compile_options(${LIB} PRIVATE -Wall -Wextra -Wpedantic -Werror)
-endif()
+# Unfortunately, these dont compile with blosc2 due to its use of getenv
+# if(MSVC)
+# 	target_compile_options(${LIB} PRIVATE "/MP")
+# 	target_compile_options(${LIB} PRIVATE /W4 /WX)
+# else()
+# 	target_compile_options(${LIB} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+# endif()
 
 # Include blosc2 headers
 include_directories("${CMAKE_SOURCE_DIR}/thirdparty/c-blosc2/include")

--- a/PhotoshopAPI/CMakeLists.txt
+++ b/PhotoshopAPI/CMakeLists.txt
@@ -21,3 +21,6 @@ if(MSVC)
 else()
 	target_compile_options(${LIB} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
+
+# Include blosc2 headers
+include_directories("${CMAKE_SOURCE_DIR}/thirdparty/c-blosc2/include")

--- a/PhotoshopAPI/src/PhotoshopFile/ImageData.h
+++ b/PhotoshopAPI/src/PhotoshopFile/ImageData.h
@@ -1,1 +1,3 @@
 #pragma once
+
+#include "blosc2.h"

--- a/PhotoshopAPI/src/Util/Compression/RLE.h
+++ b/PhotoshopAPI/src/Util/Compression/RLE.h
@@ -1,0 +1,54 @@
+#include "../../Macros.h"
+#include "../Read.h"
+#include "../Struct/File.h"
+#include "../../PhotoshopFile/FileHeader.h"
+
+
+
+// Decompresses an image buffer encoded in RLE format,
+// Assumes that data is already converted from BE into native
+template<typename T>
+inline std::vector<T> DecompressRLE(File& document, const FileHeader& header, const uint32_t width, const uint32_t height)
+{
+	std::vector<T> decompressedData(sizeof(T) * static_cast<uint64_t>(width) * static_cast<uint64_t>(height));
+
+	// Photoshop first stores the byte counts of all the scanlines, this is 2 or 4 bytes depending on 
+	// if the document is PSD or PSB
+	std::vector<uint32_t> scanlineSizes(height);
+	uint64_t scanlineTotalSize = 0u;
+	for (int i = 0; i < height; ++i)
+	{
+		scanlineSizes.push_back(ExtractWidestValue<uint16_t, uint32_t>(ReadBinaryDataVariadic<uint16_t, uint32_t>(document)));
+		scanlineTotalSize += scanlineSizes[i];
+	}
+
+	// Read the data without converting from BE to native as we need to decompress first
+	std::vector<uint8_t> data(scanlineTotalSize);
+	document.read(reinterpret_cast<char*>(data.data()), scanlineTotalSize);
+
+
+	// Decompress using the PackBits algorithm
+	{
+		size_t i = 0;
+		while (i < data.size()) {
+			uint8_t value = data[i];
+
+			if (value == 128) {
+				// Do nothing, nop
+			}
+			else if (value > 128) {
+				// Repeated byte
+				value = 256 - value;
+				decompressedData.insert(decompressedData.end(), value + 1, data[i + 1]);
+				++i;
+			}
+			else {
+				// Literal bytes
+				decompressedData.insert(decompressedData.end(), data.begin() + i + 1, data.begin() + i + value + 1);
+				i += value;
+			}
+		}
+	}
+
+	return std::move(decompressedData);
+};

--- a/PhotoshopAPI/src/Util/Read.h
+++ b/PhotoshopAPI/src/Util/Read.h
@@ -76,7 +76,7 @@ TPsb ExtractWidestValue(std::variant<TPsd, TPsb> variant)
 
 
 
-// Read a large amount of data into a std::vector for use on large amounts of data,
+// Read a large amount of data into a std::vector,
 // assumes the file is already open for reading
 template <typename T>
 inline std::vector<T> ReadBinaryArray(File& document, uint64_t size)

--- a/PhotoshopTest/CMakeLists.txt
+++ b/PhotoshopTest/CMakeLists.txt
@@ -2,20 +2,26 @@ set (EXE PhotoshopTest)
 project(${EXE})
 
 add_executable(${EXE} ${PROJECT_SOURCE_DIR}/src/main.cpp)
+
+# Unfortunately, these dont compile with blosc2 due to its use of getenv
+# if(MSVC)
+# 	target_compile_options(${LIB} PRIVATE "/MP")
+# 	target_compile_options(${LIB} PRIVATE /W4 /WX)
+# else()
+# 	target_compile_options(${LIB} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+# endif()
+
 # Include and link the PhotoshopAPI
 include_directories(${CMAKE_SOURCE_DIR}/PhotoshopAPI/src)
 target_link_libraries(${EXE} PRIVATE PhotoshopAPI)
+
+# Include and link blosc2
+include_directories("${CMAKE_SOURCE_DIR}/thirdparty/c-blosc2/include")
+target_link_libraries(${EXE} PRIVATE blosc2_static)
+
 
 # Copy the documents/ folder to the build dir
 add_custom_command(TARGET ${EXE} POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
                        ${PROJECT_SOURCE_DIR}/documents/ $<TARGET_FILE_DIR:${EXE}>/documents/)
 
-
-
-if(MSVC)
-	target_compile_options(${EXE} PRIVATE "/MP")
-	target_compile_options(${EXE} PRIVATE /W4 /WX)
-else()
-	target_compile_options(${EXE} PRIVATE -Wall -Wextra -Wpedantic -Werror)
-endif()


### PR DESCRIPTION
We do this for in-memory compression to avoid excessive memory usage when reading large Photoshop files or multiple at the same time. Additionally it ships with zlib-ng which will be used to decompress zip data