### PR TITLE
Refactor Internal Image Structure in PhotoshopFile

### DIFF
--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/GroupLayer.cpp
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/GroupLayer.cpp
@@ -12,7 +12,7 @@ template struct GroupLayer<float32_t>;
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
 template <typename T>
-GroupLayer<T>::GroupLayer(const LayerRecord& layerRecord, const std::shared_ptr<ChannelImageData<T>> channelImageData) : Layer<T>(layerRecord, channelImageData)
+GroupLayer<T>::GroupLayer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData) : Layer<T>(layerRecord, channelImageData)
 {
 }
 

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/GroupLayer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/GroupLayer.h
@@ -31,7 +31,7 @@ struct GroupLayer : public Layer<T>
 {
 	std::vector<layerVariant<T>> m_Layers;
 
-	GroupLayer(const LayerRecord& layerRecord, const std::shared_ptr<ChannelImageData<T>> channelImageData);
+	GroupLayer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData);
 };
 
 

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/ImageLayer.cpp
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/ImageLayer.cpp
@@ -15,7 +15,7 @@ template struct ImageLayer<float32_t>;
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
 template <typename T>
-ImageLayer<T>::ImageLayer(const LayerRecord& layerRecord, const std::shared_ptr<ChannelImageData<T>> channelImageData) : Layer<T>(layerRecord, channelImageData)
+ImageLayer<T>::ImageLayer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData) : Layer<T>(layerRecord, channelImageData)
 {
 	
 }

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/ImageLayer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/ImageLayer.h
@@ -16,7 +16,7 @@ struct ImageLayer : public Layer<T>
 	// Store the image data as a per-channel map to be used later
 	std::unordered_map<Enum::ChannelID, std::vector<T>> m_ImageData;
 
-	ImageLayer(const LayerRecord& layerRecord, const std::shared_ptr<ChannelImageData<T>> channelImageData);
+	ImageLayer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData);
 };
 
 PSAPI_NAMESPACE_END

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
@@ -23,7 +23,7 @@ struct Layer
 	uint64_t m_Width;
 	uint64_t m_Height;
 
-	Layer(const LayerRecord& layerRecord, const std::shared_ptr<ChannelImageData<T>> channelImageData)
+	Layer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData)
 	{
 		m_LayerName = layerRecord.m_LayerName.m_String;
 		// To parse the blend mode we must actually check for the presence of the sectionDivider blendMode as this overrides the layerRecord

--- a/PhotoshopAPI/src/LayeredFile/LayeredFile.h
+++ b/PhotoshopAPI/src/LayeredFile/LayeredFile.h
@@ -58,16 +58,16 @@ namespace LayeredFileImpl
 	template <typename T>
 	std::vector<layerVariant<T>> buildLayerHierarchyRecurse(
 		const std::vector<LayerRecord>& layerRecords,
-		const std::vector<std::shared_ptr<BaseChannelImageData>>& channelImageData,
+		const std::vector<ChannelImageData>& channelImageData,
 		std::vector<LayerRecord>::reverse_iterator& layerRecordsIterator,
-		typename std::vector<std::shared_ptr<BaseChannelImageData>>::reverse_iterator& channelImageDataIterator);
+		std::vector<ChannelImageData>::reverse_iterator& channelImageDataIterator);
 
 
 	// Identify the type of layer the current layer record represents and return a layerVariant object (std::variant<ImageLayer, GroupLayer ...>)
 	// initialized with the given layer record and corresponding channel image data.
 	// This function was heavily inspired by the psd-tools library as they have the most coherent parsing of this information
 	template <typename T>
-	layerVariant<T> identifyLayerType(const LayerRecord& layerRecord, std::shared_ptr<ChannelImageData<T>> channelImageData);
+	layerVariant<T> identifyLayerType(const LayerRecord& layerRecord, const ChannelImageData& channelImageData);
 
 }
 

--- a/PhotoshopAPI/src/Util/Struct/ImageChannel.h
+++ b/PhotoshopAPI/src/Util/Struct/ImageChannel.h
@@ -9,26 +9,12 @@
 PSAPI_NAMESPACE_BEGIN
 
 
-
-// A generic Image Channel that could either be part of the Channel Image Data section or Image Data section
-// It is entirely valid to have each channel have a different compression method, width and height. We only
-// store the image data in here but do not deal with reading or writing it. Ownership of the image data belongs
-// to this struct
-template <typename T>
-struct ImageChannel
+struct BaseImageChannel
 {
 	Enum::Compression m_Compression = Enum::Compression::Raw;
 	Enum::ChannelID m_ChannelID = Enum::ChannelID::Red;
-	std::vector<T> m_ImageData;
 
-	ImageChannel() = default;
-	ImageChannel(const ImageChannel&) = delete;
-	ImageChannel(ImageChannel&&) = default;
-	ImageChannel& operator=(const ImageChannel&) = delete;
-	ImageChannel& operator=(ImageChannel&&) = default;
-
-	// Take a reference to a decompressed image vector stream and set the according member variables
-	ImageChannel(Enum::Compression compression, std::vector<T> imageData, const Enum::ChannelID channelID, const uint32_t width, const uint32_t height)
+	BaseImageChannel(Enum::Compression compression, const Enum::ChannelID channelID, const uint32_t width, const uint32_t height)
 	{
 		if (width > 300000u)
 		{
@@ -41,16 +27,40 @@ struct ImageChannel
 				height)
 		}
 
-		this->m_Compression = compression;
-		this->m_ImageData = std::move(imageData);
-		this->m_Width = width;
-		this->m_Height = height;
-		this->m_ChannelID = channelID;
-	};
+		m_Compression = compression;
+		m_Width = width;
+		m_Height = height;
+		m_ChannelID = channelID;
+	}
 
-private:
+	virtual ~BaseImageChannel() = default;
+
+protected:
 	uint32_t m_Width = 0u;
 	uint32_t m_Height = 0u;
+};
+
+
+// A generic Image Channel that could either be part of the Channel Image Data section or Image Data section
+// It is entirely valid to have each channel have a different compression method, width and height. We only
+// store the image data in here but do not deal with reading or writing it. Ownership of the image data belongs
+// to this struct
+template <typename T>
+struct ImageChannel : public BaseImageChannel
+{
+	// Take a reference to a decompressed image vector stream and set the according member variables
+	ImageChannel(Enum::Compression compression, std::vector<T> imageData, const Enum::ChannelID channelID, const uint32_t width, const uint32_t height) : BaseImageChannel(compression, channelID, width, height)
+	{
+		m_Data = std::move(imageData);
+	};
+
+
+	std::vector<T>& getData() {
+		return m_Data;
+	}
+
+private:
+	std::vector<T> m_Data;
 };
 
 

--- a/PhotoshopTest/src/TestCompression/TestRLE.cpp
+++ b/PhotoshopTest/src/TestCompression/TestRLE.cpp
@@ -72,34 +72,30 @@ TEST_CASE("Decompress file with RLE compression")
 
 		SUBCASE("Channels are correct")
 		{
-			// Get a pointer to the data
-			std::shared_ptr<NAMESPACE_PSAPI::BaseChannelImageData> channelImageDataPtr = layerInformation.m_ChannelImageData.at(layerIndex);
-			if (auto channelImageDataView = dynamic_cast<NAMESPACE_PSAPI::ChannelImageData<uint8_t>*>(channelImageDataPtr.get()))
-			{
-				int channel_r_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
-				int channel_g_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
-				int channel_b_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
-				int channel_a_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+			
+			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
+			
+			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
+			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
+			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
+			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
 
-				CHECK(channel_r_index != -1);
-				CHECK(channel_g_index != -1);
-				CHECK(channel_b_index != -1);
-				CHECK(channel_a_index != -1);
+			CHECK(channel_r_index != -1);
+			CHECK(channel_g_index != -1);
+			CHECK(channel_b_index != -1);
+			CHECK(channel_a_index != -1);
 
-				std::vector<uint8_t> expected_r(64 * 64, 255);
-				std::vector<uint8_t> expected_bg(64 * 64, 0);
+			std::vector<uint8_t> expected_r(64 * 64, 255);
+			std::vector<uint8_t> expected_bg(64 * 64, 0);
 
-				CHECK(channelImageDataView->m_ImageData.at(channel_r_index).m_ImageData == expected_r);
-				CHECK(channelImageDataView->m_ImageData.at(channel_g_index).m_ImageData == expected_bg);
-				CHECK(channelImageDataView->m_ImageData.at(channel_b_index).m_ImageData == expected_bg);
-				// Alpha channel is white
-				CHECK(channelImageDataView->m_ImageData.at(channel_a_index).m_ImageData == expected_r);
-			}
-			else
-			{
-				// Fail the check as we were unable to cast to the appropriate type
-				REQUIRE(false);
-			}
+			// We could also extract directly using this signature and skip the step above
+			// channelImageData.extractImageData<uint8_t>(NAMESPACE_PSAPI::Enum::ChannelID::Red)
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_r_index) == expected_r);
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_g_index) == expected_bg);
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_b_index) == expected_bg);
+			// Alpha channel is white
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_a_index) == expected_r);
+
 		}
 	}
 
@@ -114,40 +110,32 @@ TEST_CASE("Decompress file with RLE compression")
 
 		SUBCASE("Channels are correct")
 		{
-			// Get a pointer to the data
-			std::shared_ptr<NAMESPACE_PSAPI::BaseChannelImageData> channelImageDataPtr = layerInformation.m_ChannelImageData.at(layerIndex);
-			if (auto channelImageDataView = dynamic_cast<NAMESPACE_PSAPI::ChannelImageData<uint8_t>*>(channelImageDataPtr.get()))
+			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
+
+			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
+			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
+			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
+			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+
+			CHECK(channel_r_index != -1);
+			CHECK(channel_g_index != -1);
+			CHECK(channel_b_index != -1);
+			CHECK(channel_a_index != -1);
+
+			// Fill the first row with white values
+			std::vector<uint8_t> expected_r(64 * 64, 0);
+			for (int i = 0; i < 64; ++i)
 			{
-				int channel_r_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
-				int channel_g_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
-				int channel_b_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
-				int channel_a_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
-
-				CHECK(channel_r_index != -1);
-				CHECK(channel_g_index != -1);
-				CHECK(channel_b_index != -1);
-				CHECK(channel_a_index != -1);
-
-				// Fill the first row with white values
-				std::vector<uint8_t> expected_r(64 * 64, 0);
-				for (int i = 0; i < 64; ++i)
-				{
-					expected_r[i] = 255;
-				}
-				std::vector<uint8_t> expected_bg(64 * 64, 0);
-				std::vector<uint8_t> expected_a(64 * 64, 255);
-
-				CHECK(channelImageDataView->m_ImageData.at(channel_r_index).m_ImageData == expected_r);
-				CHECK(channelImageDataView->m_ImageData.at(channel_g_index).m_ImageData == expected_bg);
-				CHECK(channelImageDataView->m_ImageData.at(channel_b_index).m_ImageData == expected_bg);
-				// Alpha channel is white
-				CHECK(channelImageDataView->m_ImageData.at(channel_a_index).m_ImageData == expected_a);
+				expected_r[i] = 255;
 			}
-			else
-			{
-				// Fail the check as we were unable to cast to the appropriate type
-				REQUIRE(false);
-			}
+			std::vector<uint8_t> expected_bg(64 * 64, 0);
+			std::vector<uint8_t> expected_a(64 * 64, 255);
+
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_r_index) == expected_r);
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_g_index) == expected_bg);
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_b_index) == expected_bg);
+			// Alpha channel is white
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_a_index) == expected_a);
 		}
 	}
 
@@ -163,36 +151,28 @@ TEST_CASE("Decompress file with RLE compression")
 
 		SUBCASE("Channels are correct")
 		{
-			// Get a raw pointer to the data
-			std::shared_ptr<NAMESPACE_PSAPI::BaseChannelImageData> channelImageDataPtr = layerInformation.m_ChannelImageData.at(layerIndex);
-			if (auto channelImageDataView = dynamic_cast<NAMESPACE_PSAPI::ChannelImageData<uint8_t>*>(channelImageDataPtr.get()))
-			{
-				int channel_r_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
-				int channel_g_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
-				int channel_b_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
-				int channel_a_index = channelImageDataView->getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
 
-				CHECK(channel_r_index != -1);
-				CHECK(channel_g_index != -1);
-				CHECK(channel_b_index != -1);
-				CHECK(channel_a_index != -1);
+			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
+			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
+			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
+			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+
+			CHECK(channel_r_index != -1);
+			CHECK(channel_g_index != -1);
+			CHECK(channel_b_index != -1);
+			CHECK(channel_a_index != -1);
 
 				
-				std::vector<uint8_t> expected_r(64 * 64, 255);
-				std::vector<uint8_t> expected_g(64 * 64, 128);
-				std::vector<uint8_t> expected_b(64 * 64, 0);
+			std::vector<uint8_t> expected_r(64 * 64, 255);
+			std::vector<uint8_t> expected_g(64 * 64, 128);
+			std::vector<uint8_t> expected_b(64 * 64, 0);
 
-				CHECK(channelImageDataView->m_ImageData.at(channel_r_index).m_ImageData == expected_r);
-				CHECK(channelImageDataView->m_ImageData.at(channel_g_index).m_ImageData == expected_g);
-				CHECK(channelImageDataView->m_ImageData.at(channel_b_index).m_ImageData == expected_b);
-				// Alpha channel is white
-				CHECK(channelImageDataView->m_ImageData.at(channel_a_index).m_ImageData == expected_r);
-			}
-			else
-			{
-				// Fail the check as we were unable to cast to the appropriate type
-				REQUIRE(false);
-			}
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_r_index) == expected_r);
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_g_index) == expected_g);
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_b_index) == expected_b);
+			// Alpha channel is white
+			CHECK(channelImageData.extractImageData<uint8_t>(channel_a_index) == expected_r);
 		}
 	}
 


### PR DESCRIPTION
Make channelImageData non templated and instead add utility function to transfer image data membership. Also make image data unique_ptr to be explicit about ownership