### PR TITLE
Restructure Tagged Blocks

### DIFF
--- a/PhotoshopAPI/CMakeLists.txt
+++ b/PhotoshopAPI/CMakeLists.txt
@@ -40,3 +40,9 @@ if(MSVC)
 # else()
 # 	target_compile_options(${LIB} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
+
+
+target_compile_options(${LIB} PRIVATE "$<$<CONFIG:Release>:/Zi>")
+target_link_options(${LIB} PRIVATE "$<$<CONFIG:Release>:/DEBUG>")
+target_link_options(${LIB} PRIVATE "$<$<CONFIG:Release>:/OPT:REF>")
+target_link_options(${LIB} PRIVATE "$<$<CONFIG:Release>:/OPT:ICF>")

--- a/PhotoshopAPI/CMakeLists.txt
+++ b/PhotoshopAPI/CMakeLists.txt
@@ -4,18 +4,21 @@ project(${LIB})
 # Add additional source directories here if needed
 add_library (${LIB} STATIC 
 	"${PROJECT_SOURCE_DIR}/src/LayeredFile/LayeredFile.cpp"
+	"${PROJECT_SOURCE_DIR}/src/LayeredFile/LayerTypes/Layer.cpp"
 	"${PROJECT_SOURCE_DIR}/src/LayeredFile/LayerTypes/ImageLayer.cpp"
 	"${PROJECT_SOURCE_DIR}/src/LayeredFile/LayerTypes/GroupLayer.cpp"
 	"${PROJECT_SOURCE_DIR}/src/PhotoshopFile/ColorModeData.cpp"
 	"${PROJECT_SOURCE_DIR}/src/PhotoshopFile/FileHeader.cpp"
 	"${PROJECT_SOURCE_DIR}/src/PhotoshopFile/ImageResources.cpp"
 	"${PROJECT_SOURCE_DIR}/src/PhotoshopFile/LayerAndMaskInformation.cpp"
+	"${PROJECT_SOURCE_DIR}/src/PhotoshopFile/AdditionalLayerInfo.cpp"
 	"${PROJECT_SOURCE_DIR}/src/PhotoshopFile/PhotoshopFile.cpp"
 	"${PROJECT_SOURCE_DIR}/src/Util/Struct/File.cpp"
 	"${PROJECT_SOURCE_DIR}/src/Util/Struct/PascalString.cpp"
 	"${PROJECT_SOURCE_DIR}/src/Util/Struct/ResourceBlock.cpp"
 	"${PROJECT_SOURCE_DIR}/src/Util/Struct/Signature.cpp"
 	"${PROJECT_SOURCE_DIR}/src/Util/Struct/TaggedBlock.cpp"
+	"${PROJECT_SOURCE_DIR}/src/Util/Struct/TaggedBlockStorage.cpp"
 )
 
 

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.cpp
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.cpp
@@ -1,0 +1,46 @@
+#include "Layer.h"
+
+#include "Macros.h"
+#include "Enum.h"
+#include "PhotoshopFile/LayerAndMaskInformation.h"
+#include "PhotoshopFile/AdditionalLayerInfo.h"
+#include "Struct/TaggedBlock.h"
+
+#include <vector>
+#include <optional>
+#include <string>
+
+PSAPI_NAMESPACE_BEGIN
+
+// Instantiate the template types for Layer
+template struct Layer<uint8_t>;
+template struct Layer<uint16_t>;
+template struct Layer<float32_t>;
+
+template <typename T>
+Layer<T>::Layer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData)
+{
+	m_LayerName = layerRecord.m_LayerName.m_String;
+	// To parse the blend mode we must actually check for the presence of the sectionDivider blendMode as this overrides the layerRecord
+	// blendmode if it is present
+	{
+		auto& additionalLayerInfo = layerRecord.m_AdditionalLayerInfo.value();
+		auto sectionDivider = additionalLayerInfo.getTaggedBlock<LrSectionTaggedBlock>(Enum::TaggedBlockKey::lrSectionDivider);
+		if (sectionDivider.has_value() && sectionDivider.value()->m_BlendMode.has_value())
+		{
+			m_BlendMode = sectionDivider.value()->m_BlendMode.value();
+		}
+		else
+		{
+			m_BlendMode = layerRecord.m_BlendMode;
+		}
+	}
+	m_Opacity = layerRecord.m_Opacity;
+	m_Width = static_cast<uint64_t>(layerRecord.m_Right) - layerRecord.m_Left;
+	m_Height = static_cast<uint64_t>(layerRecord.m_Bottom) - layerRecord.m_Top;
+}
+
+
+
+
+PSAPI_NAMESPACE_END

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
@@ -23,27 +23,7 @@ struct Layer
 	uint64_t m_Width;
 	uint64_t m_Height;
 
-	Layer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData)
-	{
-		m_LayerName = layerRecord.m_LayerName.m_String;
-		// To parse the blend mode we must actually check for the presence of the sectionDivider blendMode as this overrides the layerRecord
-		// blendmode if it is present
-		{
-			auto& additionalLayerInfo = layerRecord.m_AdditionalLayerInfo.value();
-			auto sectionDivider = additionalLayerInfo.getTaggedBlock<TaggedBlock::LayerSectionDivider>(Enum::TaggedBlockKey::lrSectionDivider);
-			if (sectionDivider.has_value() && sectionDivider.value()->m_BlendMode.has_value())
-			{
-				m_BlendMode = sectionDivider.value()->m_BlendMode.value();
-			}
-			else
-			{
-				m_BlendMode = layerRecord.m_BlendMode;
-			}
-		}
-		m_Opacity = layerRecord.m_Opacity;
-		m_Width = static_cast<uint64_t>(layerRecord.m_Right) - layerRecord.m_Left;
-		m_Height = static_cast<uint64_t>(layerRecord.m_Bottom) - layerRecord.m_Top;
-	}
+	Layer(const LayerRecord& layerRecord, const ChannelImageData& channelImageData);
 };
 
 PSAPI_NAMESPACE_END

--- a/PhotoshopAPI/src/LayeredFile/LayeredFile.cpp
+++ b/PhotoshopAPI/src/LayeredFile/LayeredFile.cpp
@@ -171,10 +171,10 @@ std::vector<layerVariant<T>> LayeredFileImpl::buildLayerHierarchyRecurse(
 template <typename T>
 layerVariant<T> LayeredFileImpl::identifyLayerType(const LayerRecord& layerRecord, const ChannelImageData& channelImageData)
 {
-	auto& additionalLayerInfo = layerRecord.m_AdditionalLayerInfo.value();
+	const AdditionalLayerInfo& additionalLayerInfo = layerRecord.m_AdditionalLayerInfo.value();
 
 	// Check for GroupLayer, ArtboardLayer or SectionDividerLayer
-	auto sectionDividerTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock::LayerSectionDivider>(Enum::TaggedBlockKey::lrSectionDivider);
+	auto sectionDividerTaggedBlock = additionalLayerInfo.getTaggedBlock<LrSectionTaggedBlock>(Enum::TaggedBlockKey::lrSectionDivider);
 	if (sectionDividerTaggedBlock.has_value())
 	{
 		if (sectionDividerTaggedBlock.value()->m_Type == Enum::SectionDivider::ClosedFolder
@@ -182,7 +182,7 @@ layerVariant<T> LayeredFileImpl::identifyLayerType(const LayerRecord& layerRecor
 		{
 			// This may actually house not only a group layer, but potentially also an artboard layer which we check for first
 			// These are, as of yet, unsupported. Therefore we simply return an empty container
-			auto artboardTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock::Generic>(Enum::TaggedBlockKey::lrArtboard);
+			auto artboardTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock>(Enum::TaggedBlockKey::lrArtboard);
 			if (artboardTaggedBlock.has_value())
 			{
 				return ArtboardLayer<T>();
@@ -198,14 +198,14 @@ layerVariant<T> LayeredFileImpl::identifyLayerType(const LayerRecord& layerRecor
 	}
 
 	// Check for Text Layers
-	auto typeToolTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock::Generic>(Enum::TaggedBlockKey::lrTypeTool);
+	auto typeToolTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock>(Enum::TaggedBlockKey::lrTypeTool);
 	if (typeToolTaggedBlock.has_value())
 	{
 		return TextLayer<T>();
 	}
 
 	// Check for Smart Object Layers
-	auto smartObjectTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock::Generic>(Enum::TaggedBlockKey::lrSmartObject);
+	auto smartObjectTaggedBlock = additionalLayerInfo.getTaggedBlock<TaggedBlock>(Enum::TaggedBlockKey::lrSmartObject);
 	if (typeToolTaggedBlock.has_value())
 	{
 		return SmartObjectLayer<T>();
@@ -214,7 +214,7 @@ layerVariant<T> LayeredFileImpl::identifyLayerType(const LayerRecord& layerRecor
 	// Check if it is one of many adjustment layers
 	// We do not currently implement these but it would be worth investigating
 	{
-#define getGenericTaggedBlock additionalLayerInfo.getTaggedBlock<TaggedBlock::Generic>
+#define getGenericTaggedBlock additionalLayerInfo.getTaggedBlock<TaggedBlock>
 
 		auto blackAndWhiteTaggedBlock = getGenericTaggedBlock(Enum::TaggedBlockKey::adjBlackandWhite);
 		auto gradientTaggedBlock = getGenericTaggedBlock(Enum::TaggedBlockKey::adjGradient);
@@ -266,7 +266,7 @@ layerVariant<T> LayeredFileImpl::identifyLayerType(const LayerRecord& layerRecor
 	
 	// Now the layer could only be one of two more. A shape or pixel layer (Note files written before CS6 could fail this shape layer check here
 	{
-#define getGenericTaggedBlock additionalLayerInfo.getTaggedBlock<TaggedBlock::Generic>
+#define getGenericTaggedBlock additionalLayerInfo.getTaggedBlock<TaggedBlock>
 		
 		{
 			auto vecOriginDataTaggedBlock = getGenericTaggedBlock(Enum::TaggedBlockKey::vecOriginData);

--- a/PhotoshopAPI/src/PhotoshopFile/AdditionalLayerInfo.cpp
+++ b/PhotoshopAPI/src/PhotoshopFile/AdditionalLayerInfo.cpp
@@ -1,0 +1,41 @@
+#include "AdditionalLayerInfo.h"
+#include "LayerAndMaskInformation.h"
+#include "FileHeader.h"
+#include "Struct/TaggedBlock.h"
+
+#include <memory>
+#include <optional>
+
+PSAPI_NAMESPACE_BEGIN
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+AdditionalLayerInfo::AdditionalLayerInfo(File& document, const FileHeader& header, const uint64_t offset, const uint64_t maxLength, const uint16_t padding)
+{
+	m_Offset = offset;
+	document.setOffset(offset);
+	m_Size = 0u;
+
+	int64_t toRead = maxLength;
+	while (toRead >= 12u)
+	{
+		const std::shared_ptr<TaggedBlock> taggedBlock = this->m_TaggedBlocks.readTaggedBlock(document, header, padding);
+		toRead -= taggedBlock->getTotalSize();
+		m_Size += taggedBlock->getTotalSize();
+	}
+	if (toRead >= 0)
+	{
+		m_Size += toRead;
+		document.skip(toRead);
+		return;
+	}
+
+	if (toRead <= 0)
+	{
+		PSAPI_LOG_WARNING("AdditionalLayerInfo", "Read too much data for the additional layer info, was allowed %" PRIu64 " but read %" PRIu64 " instead",
+			maxLength, maxLength - toRead);
+	}
+}
+
+PSAPI_NAMESPACE_END

--- a/PhotoshopAPI/src/PhotoshopFile/AdditionalLayerInfo.h
+++ b/PhotoshopAPI/src/PhotoshopFile/AdditionalLayerInfo.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "Macros.h"
+#include "Enum.h"
+#include "Struct/File.h"
+#include "Struct/Section.h"
+#include "Struct/TaggedBlockStorage.h"
+#include "FileHeader.h"
+
+#include <vector>
+#include <memory>
+#include <optional>
+
+
+PSAPI_NAMESPACE_BEGIN
+
+
+struct AdditionalLayerInfo : public FileSection
+{
+	TaggedBlockStorage m_TaggedBlocks;
+
+	AdditionalLayerInfo() = default;
+	AdditionalLayerInfo(const AdditionalLayerInfo&) = delete;
+	AdditionalLayerInfo(AdditionalLayerInfo&&) = default;
+	AdditionalLayerInfo& operator=(const AdditionalLayerInfo&) = delete;
+	AdditionalLayerInfo& operator=(AdditionalLayerInfo&&) = default;
+
+	AdditionalLayerInfo(File& document, const FileHeader& header, const uint64_t offset, const uint64_t maxLength, const uint16_t padding = 1u);
+
+	// Get a tagged block from the key and try to cast it to T. If key cannot be found return nullptr
+	template <typename T>
+	std::optional<std::shared_ptr<T>> getTaggedBlock(const Enum::TaggedBlockKey key) const
+	{
+		// If it is a nullptr we return nullopt
+		std::shared_ptr<T> taggedBlockPtr = this->m_TaggedBlocks.getTaggedBlockView<T>(key);
+		if (taggedBlockPtr)
+		{
+			return taggedBlockPtr;
+		}
+		return std::nullopt;
+	}
+};
+
+PSAPI_NAMESPACE_END

--- a/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.cpp
+++ b/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.cpp
@@ -4,8 +4,6 @@
 #include "Macros.h"
 #include "Read.h"
 #include "StringUtil.h"
-#include "Struct/TaggedBlock.h"
-
 
 #include <variant>
 
@@ -356,37 +354,6 @@ ChannelImageData::ChannelImageData(File& document, const FileHeader& header, con
 			std::vector<float32_t> decompressedData = DecompressData<float32_t>(document, channelCompression, header, width, height, channel.m_Size - 2u);
 			this->m_ImageData.push_back(std::make_unique<ImageChannel<float32_t>>(channelCompression, decompressedData, channel.m_ChannelID, width, height));
 		}
-	}
-}
-
-
-// ---------------------------------------------------------------------------------------------------------------------
-// ---------------------------------------------------------------------------------------------------------------------
-AdditionalLayerInfo::AdditionalLayerInfo(File& document, const FileHeader& header, const uint64_t offset, const uint64_t maxLength, const uint16_t padding)
-{
-	m_Offset = offset;
-	document.setOffset(offset);
-	m_Size = 0u;
-
-	int64_t toRead = maxLength;
-	while (toRead >= 12u)
-	{
-		std::shared_ptr<TaggedBlock::Base> taggedBlock = readTaggedBlock(document, header, padding);
-		toRead -= taggedBlock->getTotalSize();
-		m_Size += taggedBlock->getTotalSize();
-		m_TaggedBlocks.push_back(std::move(taggedBlock));
-	}
-	if (toRead >= 0)
-	{
-		m_Size += toRead;
-		document.skip(toRead);
-		return;
-	}
-
-	if (toRead <= 0)
-	{
-		PSAPI_LOG_WARNING("AdditionalLayerInfo", "Read too much data for the additional layer info, was allowed %" PRIu64 " but read %" PRIu64 " instead",
-			maxLength, maxLength - toRead);
 	}
 }
 

--- a/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.h
+++ b/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.h
@@ -1,57 +1,21 @@
 #pragma once
 
 #include "FileHeader.h"
+#include "AdditionalLayerInfo.h"
 #include "Macros.h"
 #include "Enum.h"
 #include "Struct/File.h"
 #include "Struct/Section.h"
 #include "Struct/ResourceBlock.h"
-#include "Struct/TaggedBlock.h"
 #include "Struct/ImageChannel.h"
 #include "Compression/Compression.h"
-
 
 #include <vector>
 #include <memory>
 
 
+
 PSAPI_NAMESPACE_BEGIN
-
-
-struct AdditionalLayerInfo : public FileSection
-{
-	std::vector<std::shared_ptr<TaggedBlock::Base>> m_TaggedBlocks;
-
-	AdditionalLayerInfo() = default;
-	AdditionalLayerInfo(const AdditionalLayerInfo&) = delete;
-	AdditionalLayerInfo(AdditionalLayerInfo&&) = default;
-	AdditionalLayerInfo& operator=(const AdditionalLayerInfo&) = delete;
-	AdditionalLayerInfo& operator=(AdditionalLayerInfo&&) = default;
-
-	AdditionalLayerInfo(File& document, const FileHeader& header, const uint64_t offset, const uint64_t maxLength, const uint16_t padding = 1u);
-
-	// Retrieve a pointer to a TaggedBlock based on the key given. If the key does not exist, we return std::nullopt
-	template <typename T>
-	std::optional<std::shared_ptr<T>> getTaggedBlock(const Enum::TaggedBlockKey key) const
-	{
-		for (auto& taggedBlock : m_TaggedBlocks)
-		{
-			if (taggedBlock->getKey() == key)
-			{
-				auto downcastedPtr = std::static_pointer_cast<T>(taggedBlock);
-				if (downcastedPtr)
-				{
-					return downcastedPtr;
-				}
-				else
-				{
-					PSAPI_LOG_ERROR("AdditionalLayerInfo", "Unable to cast Base Tagged Block to template argument");
-				}
-			}
-		}
-		return std::nullopt;
-	}
-};
 
 
 // Structs to hold the different types of data found in the layer records themselves
@@ -114,7 +78,6 @@ namespace LayerRecords
 		uint32_t m_Size = 4u;	// Includes the section length marker
 		std::optional<LayerMask> m_LayerMask;
 		std::optional<LayerMask> m_VectorMask;
-
 
 		LayerMaskData() {};
 		LayerMaskData(File& document);

--- a/PhotoshopAPI/src/Util/Compression/ZIP.h
+++ b/PhotoshopAPI/src/Util/Compression/ZIP.h
@@ -6,6 +6,7 @@
 
 #include "zlib-ng.h"
 
+#include <algorithm>
 
 PSAPI_NAMESPACE_BEGIN
 
@@ -76,7 +77,7 @@ std::vector<T> RemovePredictionEncoding(const std::vector<uint8_t>& decompressed
 	if (bitShiftedData.size() != static_cast<uint64_t>(height) * static_cast<uint64_t>(width))
 	{
 		PSAPI_LOG_ERROR("RemovePredictionEncoding", "Endian Decoded data does not match expected size, expected %" PRIu64 ", got %i",
-			static_cast<uint64_t>(height) * static_cast<uint64_t>(width) * sizeof(T),
+			static_cast<uint64_t>(height) * static_cast<uint64_t>(width),
 			bitShiftedData.size())
 	}
 
@@ -92,6 +93,64 @@ std::vector<T> RemovePredictionEncoding(const std::vector<uint8_t>& decompressed
 
 	return bitShiftedData;
 }
+
+
+// We need to specialize here as 32-bit files have their bytes interleaved (i.e. from 1234 1234 1234 1234 byte order to 1111 2222 3333 4444)
+// And we need to do this de-interleaving separately. Thanks to both psd_sdk and psd-tools for having found this out
+template <>
+inline std::vector<float32_t> RemovePredictionEncoding(const std::vector<uint8_t>& decompressedData, const uint32_t width, const uint32_t height)
+{
+	std::vector<uint8_t> predictionDecodedData = decompressedData;
+
+	// Perform prediction decoding per scanline of data in-place
+	uint64_t index = 0;
+	for (uint64_t y = 0; y < height; ++y)
+	{
+		++index;
+		for (uint64_t x = 1; x < static_cast<uint64_t>(width) * 4u; ++x)
+		{
+			// Simple differencing: decode by adding the difference to the previous value
+			uint8_t value = predictionDecodedData[index] + predictionDecodedData[index - 1];
+			predictionDecodedData[index] = value;
+
+			++index;
+		}
+	}
+
+	// We now need to shuffle the byte order back in its normal place as photoshop stores the bytes deinterleaved for 32 bit types.
+	// Imagine the following sequence of bytes, 1234 1234 1234 1234. If we would encode them literally it wouldnt give us much compression
+	// which is why Photoshop deinterleaves them to 1111 2222 3333 4444 to get better compression. We now need to reverse this interleaving that is done row-by-row
+
+
+	std::vector<float32_t> bitShiftedData;
+	bitShiftedData.reserve(static_cast<uint64_t>(width) * height);
+
+	// Create a temporary byte buffer that we reuse to interleave and then immediately endianDecode
+	std::vector<uint8_t> buffer(4u, 0);
+	for (uint64_t y = 0; y < height; ++y)
+	{
+		for (uint64_t x = 0; x < width; ++x)
+		{
+			buffer[0] = predictionDecodedData[y * width * 4 + x];
+			buffer[1] = predictionDecodedData[y * width * 4 + width + x];
+			buffer[2] = predictionDecodedData[y * width * 4 + width * 2 + x];
+			buffer[3] = predictionDecodedData[y * width * 4 + width * 3 + x];
+
+			bitShiftedData.push_back(endianDecodeBE<float32_t>(buffer.data()));
+		}
+	}
+
+	if (bitShiftedData.size() != static_cast<uint64_t>(height) * static_cast<uint64_t>(width))
+	{
+		PSAPI_LOG_ERROR("RemovePredictionEncoding", "Endian Decoded data does not match expected size, expected %" PRIu64 ", got %i",
+			static_cast<uint64_t>(height) * static_cast<uint64_t>(width),
+			bitShiftedData.size())
+	}
+	
+	return bitShiftedData;
+}
+
+
 
 template <typename T>
 std::vector<T> DecompressZIPPrediction(File& document, const FileHeader& header, const uint32_t width, const uint32_t height, const uint64_t compressedSize)

--- a/PhotoshopAPI/src/Util/Struct/File.h
+++ b/PhotoshopAPI/src/Util/Struct/File.h
@@ -41,7 +41,7 @@ struct File
 	}
 
 
-	inline uint64_t getOffset()
+	inline uint64_t getOffset() const
 	{
 		return m_Offset;
 	}
@@ -63,7 +63,7 @@ struct File
 	}
 
 
-	inline uint64_t getSize()
+	inline uint64_t getSize() const
 	{
 		return m_Size;
 	}

--- a/PhotoshopAPI/src/Util/Struct/File.h
+++ b/PhotoshopAPI/src/Util/Struct/File.h
@@ -11,6 +11,7 @@
 
 PSAPI_NAMESPACE_BEGIN
 
+
 struct File
 {
 
@@ -24,7 +25,7 @@ struct File
 		m_Document.read(buffer, size);
 		m_Offset += size;
 	}
-
+	
 
 	inline void skip(int64_t size)
 	{

--- a/PhotoshopAPI/src/Util/Struct/TaggedBlock.cpp
+++ b/PhotoshopAPI/src/Util/Struct/TaggedBlock.cpp
@@ -6,38 +6,13 @@
 #include "StringUtil.h"
 #include "Struct/Signature.h"
 #include "Struct/File.h"
-#include "PhotoshopFile/LayerAndMaskInformation.h"
 #include "PhotoshopFile/FileHeader.h"
 
 PSAPI_NAMESPACE_BEGIN
 
-// Unfortunately we must specify these tagged blocks here as they rely on the LayerAndMaskInformation which would otherwise lead to circular dependencies
-namespace TaggedBlock
-{
-
-	// 16-bit files store this tagged block at the end of the layer and mask information section which contains the 
-	// layer info section
-	struct Lr16 : Base
-	{
-		LayerInfo m_Data;
-
-		Lr16(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding = 1u);
-	};
-
-
-	// 32-bit files store this tagged block at the end of the layer and mask information section which contains the 
-	// layer info section
-	struct Lr32 : Base
-	{
-		LayerInfo m_Data;
-
-		Lr32(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding = 1u);
-	};
-}
-
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
-TaggedBlock::Generic::Generic(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const Enum::TaggedBlockKey key, const uint16_t padding)
+TaggedBlock::TaggedBlock(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const Enum::TaggedBlockKey key, const uint16_t padding)
 {
 	m_Offset = offset;
 	m_Signature = signature;
@@ -47,7 +22,7 @@ TaggedBlock::Generic::Generic(File& document, const FileHeader& header, const ui
 		uint64_t length = ReadBinaryData<uint64_t>(document);
 		length = RoundUpToMultiple<uint64_t>(length, padding);
 		m_Length = length;
-		m_Data = ReadBinaryArray<uint8_t>(document, std::get<uint64_t>(m_Length));
+		document.skip(length);
 
 		m_TotalLength = length + 4u + 4u + 8u;
 	}
@@ -56,7 +31,8 @@ TaggedBlock::Generic::Generic(File& document, const FileHeader& header, const ui
 		uint32_t length = ReadBinaryData<uint32_t>(document);
 		length = RoundUpToMultiple<uint32_t>(length, padding);
 		m_Length = length;
-		m_Data = ReadBinaryArray<uint8_t>(document, std::get<uint32_t>(m_Length));
+		document.skip(length);
+
 
 		m_TotalLength = static_cast<uint64_t>(length) + 4u + 4u + 4u;
 	}
@@ -65,7 +41,7 @@ TaggedBlock::Generic::Generic(File& document, const FileHeader& header, const ui
 
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
-TaggedBlock::Lr16::Lr16(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding)
+Lr16TaggedBlock::Lr16TaggedBlock(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding) 
 {
 	m_Key = Enum::TaggedBlockKey::Lr16;
 	m_Offset = offset;
@@ -81,7 +57,7 @@ TaggedBlock::Lr16::Lr16(File& document, const FileHeader& header, const uint64_t
 
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
-TaggedBlock::Lr32::Lr32(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding)
+Lr32TaggedBlock::Lr32TaggedBlock(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding)
 {
 	m_Key = Enum::TaggedBlockKey::Lr32;
 	m_Offset = offset;
@@ -97,7 +73,7 @@ TaggedBlock::Lr32::Lr32(File& document, const FileHeader& header, const uint64_t
 
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
-TaggedBlock::LayerSectionDivider::LayerSectionDivider(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding)
+LrSectionTaggedBlock::LrSectionTaggedBlock(File& document, const FileHeader& header, const uint64_t offset, const Signature signature, const uint16_t padding)
 {
 	m_Key = Enum::TaggedBlockKey::lrSectionDivider;
 	m_Offset = offset;
@@ -137,43 +113,6 @@ TaggedBlock::LayerSectionDivider::LayerSectionDivider(File& document, const File
 
 	m_TotalLength = static_cast<uint64_t>(length) + 4u + 4u + 4u;
 };
-
-
-// ---------------------------------------------------------------------------------------------------------------------
-// ---------------------------------------------------------------------------------------------------------------------
-std::shared_ptr<TaggedBlock::Base> readTaggedBlock(File& document, const FileHeader& header, const uint16_t padding)
-{
-	const uint64_t offset = document.getOffset();
-	Signature signature = Signature(ReadBinaryData<uint32_t>(document));
-	if (signature != Signature("8BIM") && signature != Signature("8B64"))
-	{
-		PSAPI_LOG_ERROR("LayerRecord", "Signature does not match '8BIM' or '8B64', got '%s' instead",
-			uint32ToString(signature.m_Value).c_str())
-	}
-	std::string keyStr = uint32ToString(ReadBinaryData<uint32_t>(document));
-	std::optional<Enum::TaggedBlockKey> taggedBlock = Enum::getTaggedBlockKey<std::string, Enum::TaggedBlockKey>(keyStr);
-	
-	if (taggedBlock.has_value())
-	{
-		switch (taggedBlock.value())
-		{
-		case Enum::TaggedBlockKey::Lr16:
-			return std::make_shared<TaggedBlock::Lr16>(document, header, offset, signature, padding);
-		case Enum::TaggedBlockKey::Lr32:
-			return std::make_shared<TaggedBlock::Lr32>(document, header, offset, signature, padding);
-		case Enum::TaggedBlockKey::lrSectionDivider:
-			return std::make_shared<TaggedBlock::LayerSectionDivider>(document, header, offset, signature, padding);
-		default:
-			return std::make_shared<TaggedBlock::Generic>(document, header, offset, signature, taggedBlock.value(), padding);
-		}
-	}
-	else
-	{
-		PSAPI_LOG_ERROR("TaggedBlock", "Could not find tagged block from key '%s'", keyStr.c_str());
-		return NULL;
-	}
-}
-
 
 PSAPI_NAMESPACE_END
 

--- a/PhotoshopAPI/src/Util/Struct/TaggedBlockStorage.cpp
+++ b/PhotoshopAPI/src/Util/Struct/TaggedBlockStorage.cpp
@@ -1,0 +1,86 @@
+#include "TaggedBlockStorage.h"
+
+#include "Macros.h"
+#include "Read.h"
+#include "Logger.h"
+#include "StringUtil.h"
+#include "TaggedBlock.h"
+
+PSAPI_NAMESPACE_BEGIN
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+template <typename T>
+std::shared_ptr<T> TaggedBlockStorage::getTaggedBlockView(const Enum::TaggedBlockKey key) const
+{
+	// iterate all tagged blocks and compare keys as well as trying to cast the pointer
+	for (auto& taggedBlock : m_TaggedBlocks)
+	{
+		if (taggedBlock->getKey() == key)
+		{
+			if (std::shared_ptr<T> downcastedPtr = std::dynamic_pointer_cast<T>(taggedBlock))
+			{
+				return downcastedPtr;
+			}
+		}
+	}
+	return nullptr;
+}
+
+// Instantiate the templates for all the tagged block types 
+template std::shared_ptr<TaggedBlock> TaggedBlockStorage::getTaggedBlockView(const Enum::TaggedBlockKey key) const;
+template std::shared_ptr<Lr16TaggedBlock> TaggedBlockStorage::getTaggedBlockView(const Enum::TaggedBlockKey key) const;
+template std::shared_ptr<Lr32TaggedBlock> TaggedBlockStorage::getTaggedBlockView(const Enum::TaggedBlockKey key) const;
+template std::shared_ptr<LrSectionTaggedBlock> TaggedBlockStorage::getTaggedBlockView(const Enum::TaggedBlockKey key) const;
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+const std::shared_ptr<TaggedBlock> TaggedBlockStorage::readTaggedBlock(File& document, const FileHeader& header, const uint16_t padding)
+{
+	const uint64_t offset = document.getOffset();
+	Signature signature = Signature(ReadBinaryData<uint32_t>(document));
+	if (signature != Signature("8BIM") && signature != Signature("8B64"))
+	{
+		PSAPI_LOG_ERROR("LayerRecord", "Signature does not match '8BIM' or '8B64', got '%s' instead",
+			uint32ToString(signature.m_Value).c_str())
+	}
+	std::string keyStr = uint32ToString(ReadBinaryData<uint32_t>(document));
+	std::optional<Enum::TaggedBlockKey> taggedBlock = Enum::getTaggedBlockKey<std::string, Enum::TaggedBlockKey>(keyStr);
+
+	if (taggedBlock.has_value())
+	{
+		if (taggedBlock.value() == Enum::TaggedBlockKey::Lr16)
+		{
+			auto lr16TaggedBlock = std::make_shared<Lr16TaggedBlock>(document, header, offset, signature, padding);
+			this->m_TaggedBlocks.push_back(lr16TaggedBlock);
+			return lr16TaggedBlock;
+		}
+		else if (taggedBlock.value() == Enum::TaggedBlockKey::Lr32)
+		{
+			auto lr32TaggedBlock = std::make_shared<Lr32TaggedBlock>(document, header, offset, signature, padding);
+			this->m_TaggedBlocks.push_back(lr32TaggedBlock);
+			return lr32TaggedBlock;
+		}
+		else if (taggedBlock.value() == Enum::TaggedBlockKey::lrSectionDivider)
+		{
+			auto lrSectionTaggedBlock = std::make_shared<LrSectionTaggedBlock>(document, header, offset, signature, padding);
+			this->m_TaggedBlocks.push_back(lrSectionTaggedBlock);
+			return lrSectionTaggedBlock;
+		}
+		else
+		{
+			auto baseTaggedBlock = std::make_shared<TaggedBlock>(document, header, offset, signature, taggedBlock.value(), padding);
+			this->m_TaggedBlocks.push_back(baseTaggedBlock);
+			return baseTaggedBlock;
+		}
+	}
+	else
+	{
+		PSAPI_LOG_ERROR("TaggedBlock", "Could not find tagged block from key '%s'", keyStr.c_str());
+		return nullptr;
+	}
+}
+
+PSAPI_NAMESPACE_END

--- a/PhotoshopAPI/src/Util/Struct/TaggedBlockStorage.h
+++ b/PhotoshopAPI/src/Util/Struct/TaggedBlockStorage.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Macros.h"
+#include "Enum.h"
+#include "PhotoshopFile/FileHeader.h"
+
+#include <memory>
+#include <vector>
+
+
+PSAPI_NAMESPACE_BEGIN
+
+// Forward declare tagged blocks
+struct TaggedBlock;
+
+// A storage container for a collection of Tagged Blocks. The specification doesnt specifically mention tagged blocks being unique but 
+// we assume so for retrieving tagged blocks. I.e if you retrieve a tagged block it will return the first instance of it
+struct TaggedBlockStorage
+{
+
+	// Retrieve the object represented by the specified tagged block. Note, this returns the first instance rather than all instances
+	// We assume tagged blocks are unique but this may not always be the case. Returns nullptr if no type is found
+	template <typename T>
+	std::shared_ptr<T> getTaggedBlockView(const Enum::TaggedBlockKey key) const;
+
+	// Read a tagged block into m_TaggedBlocks as well as returning a shared_ptr to it.
+	// The shared ptr should be used only to retrieve data, hence its markation as const
+	const std::shared_ptr<TaggedBlock> readTaggedBlock(File& document, const FileHeader& header, const uint16_t padding = 1u);
+
+private:
+	std::vector<std::shared_ptr<TaggedBlock>> m_TaggedBlocks;
+};
+
+
+PSAPI_NAMESPACE_END

--- a/PhotoshopTest/CMakeLists.txt
+++ b/PhotoshopTest/CMakeLists.txt
@@ -20,6 +20,11 @@ if(MSVC)
 # 	target_compile_options(${EXE} PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
 
+target_compile_options(${EXE} PRIVATE "$<$<CONFIG:Release>:/Zi>")
+target_link_options(${EXE} PRIVATE "$<$<CONFIG:Release>:/DEBUG>")
+target_link_options(${EXE} PRIVATE "$<$<CONFIG:Release>:/OPT:REF>")
+target_link_options(${EXE} PRIVATE "$<$<CONFIG:Release>:/OPT:ICF>")
+
 # Include and link the PhotoshopAPI
 target_include_directories(${EXE} PRIVATE "${CMAKE_SOURCE_DIR}/PhotoshopAPI/src")
 target_link_libraries(${EXE} PRIVATE PhotoshopAPI)

--- a/PhotoshopTest/CMakeLists.txt
+++ b/PhotoshopTest/CMakeLists.txt
@@ -4,8 +4,13 @@ project(${EXE})
 
 add_executable(${EXE} 
     "${PROJECT_SOURCE_DIR}/src/main.cpp"
+    "${PROJECT_SOURCE_DIR}/src/TestCompression/Utility.cpp"
     "${PROJECT_SOURCE_DIR}/src/TestCompression/TestRLE.cpp"
+    "${PROJECT_SOURCE_DIR}/src/TestCompression/TestZIPPrediction.cpp"
 )
+
+target_include_directories(${EXE} PRIVATE "${CMAKE_SOURCE_DIR}/PhotoshopTest/src/TestCompression")
+
 
 # Unfortunately, Wall doesnt compile with blosc2 due to its use of getenv
 if(MSVC)

--- a/PhotoshopTest/src/TestCompression/TestRLE.cpp
+++ b/PhotoshopTest/src/TestCompression/TestRLE.cpp
@@ -1,6 +1,7 @@
 #include "doctest.h"
 
 #include "Macros.h"
+#include "Utility.h"
 #include "Compression/RLE.h"
 #include "PhotoshopFile/PhotoshopFile.h"
 
@@ -34,147 +35,16 @@ TEST_CASE("Test Wikipedia Packbits Example")
 
 TEST_CASE("Decompress file with RLE compression")
 {
-
-	// This document is 64x64 pixels, 8 bit and its channels are all compressed using RLE
-	// There are 5 layers in total which each represent different types of data
-	//		- "LayerRed":			Layer that is entirely red, we expect the red channel to be entirely white (255) while the rest is 0
-	//		- "LayerGreen":			Same as above but entirely green
-	//		- "LayerBlue":			Same as above but entirely blue
-	//		- "LayerFirstRowRed":	The entire layer is black except for the first row which is red (255, 0, 0). We expect the data to reflect this
-	//		- "Layer_R255_G128_B0":	The layer has the R, G and B values indicated in the layer name across the whole document
-	std::filesystem::path combined_path = std::filesystem::current_path();
-	combined_path += "\\documents\\Compression\\Compression_RLE_8bit.psd";
-
-
-	NAMESPACE_PSAPI::File file(combined_path);
-	NAMESPACE_PSAPI::PhotoshopFile document;
-	bool didParse = document.read(file);
-
-	NAMESPACE_PSAPI::LayerInfo& layerInformation = document.m_LayerMaskInfo.m_LayerInfo;
-
-	SUBCASE("Check Layer Count is read correctly")
+	SUBCASE("PSD")
 	{
-		std::size_t layerRecordLength = layerInformation.m_LayerRecords.size();
-		std::size_t channelImageDataLength = layerInformation.m_ChannelImageData.size();
-
-		REQUIRE(layerRecordLength == 5);
-		REQUIRE(channelImageDataLength == 5);
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_RLE_8bit.psd";
+		checkCompressionFile<uint8_t>(combined_path, 0, 128, 255);
 	}
-
-	SUBCASE("Check 'LayerRed'")
+	SUBCASE("PSB")
 	{
-		int layerIndex = layerInformation.getLayerIndex("LayerRed");
-
-		SUBCASE("Could find layer")
-		{
-			CHECK(layerIndex != -1);
-		}
-
-		SUBCASE("Channels are correct")
-		{
-			
-			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
-			
-			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
-			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
-			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
-			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
-
-			CHECK(channel_r_index != -1);
-			CHECK(channel_g_index != -1);
-			CHECK(channel_b_index != -1);
-			CHECK(channel_a_index != -1);
-
-			std::vector<uint8_t> expected_r(64 * 64, 255);
-			std::vector<uint8_t> expected_bg(64 * 64, 0);
-
-			// We could also extract directly using this signature and skip the step above
-			// channelImageData.extractImageData<uint8_t>(NAMESPACE_PSAPI::Enum::ChannelID::Red)
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_r_index) == expected_r);
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_g_index) == expected_bg);
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_b_index) == expected_bg);
-			// Alpha channel is white
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_a_index) == expected_r);
-
-		}
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_RLE_8bit.psb";
+		checkCompressionFile<uint8_t>(combined_path, 0, 128, 255);
 	}
-
-	SUBCASE("Check 'LayerFirstRowRed'")
-	{
-		int layerIndex = layerInformation.getLayerIndex("LayerFirstRowRed");
-
-		SUBCASE("Could find layer")
-		{
-			CHECK(layerIndex != -1);
-		}
-
-		SUBCASE("Channels are correct")
-		{
-			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
-
-			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
-			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
-			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
-			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
-
-			CHECK(channel_r_index != -1);
-			CHECK(channel_g_index != -1);
-			CHECK(channel_b_index != -1);
-			CHECK(channel_a_index != -1);
-
-			// Fill the first row with white values
-			std::vector<uint8_t> expected_r(64 * 64, 0);
-			for (int i = 0; i < 64; ++i)
-			{
-				expected_r[i] = 255;
-			}
-			std::vector<uint8_t> expected_bg(64 * 64, 0);
-			std::vector<uint8_t> expected_a(64 * 64, 255);
-
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_r_index) == expected_r);
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_g_index) == expected_bg);
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_b_index) == expected_bg);
-			// Alpha channel is white
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_a_index) == expected_a);
-		}
-	}
-
-
-	SUBCASE("Check 'Layer_R255_G128_B0'")
-	{
-		int layerIndex = layerInformation.getLayerIndex("Layer_R255_G128_B0");
-
-		SUBCASE("Could find layer")
-		{
-			CHECK(layerIndex != -1);
-		}
-
-		SUBCASE("Channels are correct")
-		{
-			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
-
-			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
-			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
-			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
-			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
-
-			CHECK(channel_r_index != -1);
-			CHECK(channel_g_index != -1);
-			CHECK(channel_b_index != -1);
-			CHECK(channel_a_index != -1);
-
-				
-			std::vector<uint8_t> expected_r(64 * 64, 255);
-			std::vector<uint8_t> expected_g(64 * 64, 128);
-			std::vector<uint8_t> expected_b(64 * 64, 0);
-
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_r_index) == expected_r);
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_g_index) == expected_g);
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_b_index) == expected_b);
-			// Alpha channel is white
-			CHECK(channelImageData.extractImageData<uint8_t>(channel_a_index) == expected_r);
-		}
-	}
-
-	CHECK(didParse);
 }

--- a/PhotoshopTest/src/TestCompression/TestRLE.cpp
+++ b/PhotoshopTest/src/TestCompression/TestRLE.cpp
@@ -1,7 +1,7 @@
 #include "doctest.h"
 
-#include "Macros.h"
 #include "Utility.h"
+#include "Macros.h"
 #include "Compression/RLE.h"
 #include "PhotoshopFile/PhotoshopFile.h"
 
@@ -39,12 +39,12 @@ TEST_CASE("Decompress file with RLE compression")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_RLE_8bit.psd";
-		checkCompressionFile<uint8_t>(combined_path, 0, 128, 255);
+		checkCompressionFile<uint8_t>(combined_path, 0, 128, 255, 0);
 	}
 	SUBCASE("PSB")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_RLE_8bit.psb";
-		checkCompressionFile<uint8_t>(combined_path, 0, 128, 255);
+		checkCompressionFile<uint8_t>(combined_path, 0, 128, 255, 0);
 	}
 }

--- a/PhotoshopTest/src/TestCompression/TestZIPPrediction.cpp
+++ b/PhotoshopTest/src/TestCompression/TestZIPPrediction.cpp
@@ -16,25 +16,25 @@ TEST_CASE("Decompress 16 bit file with ZIP Prediction compression")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_16bit.psd";
-		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535, 2);
 	}
 	SUBCASE("PSB")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_16bit.psb";
-		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535, 2);
 	}
 	SUBCASE("MaximizeCompatibilityOff_PSD")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_16bit.psd";
-		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535, 2);
 	}
 	SUBCASE("MaximizeCompatibilityOff_PSB")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_16bit.psb";
-		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535, 2);
 	}
 }
 
@@ -46,24 +46,24 @@ TEST_CASE("Decompress 32 bit file with ZIP Prediction compression")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_32bit.psd";
-		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f, 0.0f);
 	}
 	SUBCASE("PSB")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_32bit.psb";
-		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f, 0.0f);
 	}
 	SUBCASE("MaximizeCompatibilityOff_PSD")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_32bit.psd";
-		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f, 0.0f);
 	}
 	SUBCASE("MaximizeCompatibilityOff_PSB")
 	{
 		std::filesystem::path combined_path = std::filesystem::current_path();
 		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_32bit.psb";
-		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f, 0.0f);
 	}
 }

--- a/PhotoshopTest/src/TestCompression/TestZIPPrediction.cpp
+++ b/PhotoshopTest/src/TestCompression/TestZIPPrediction.cpp
@@ -1,0 +1,69 @@
+#include "doctest.h"
+
+#include "Utility.h"
+#include "Macros.h"
+#include "Compression/RLE.h"
+#include "PhotoshopFile/PhotoshopFile.h"
+
+#include <vector>
+#include <filesystem>
+
+
+TEST_CASE("Decompress 16 bit file with ZIP Prediction compression")
+{
+	// We count all 4 variations of this as the same test case
+	SUBCASE("PSD")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_16bit.psd";
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+	}
+	SUBCASE("PSB")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_16bit.psb";
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+	}
+	SUBCASE("MaximizeCompatibilityOff_PSD")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_16bit.psd";
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+	}
+	SUBCASE("MaximizeCompatibilityOff_PSB")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_16bit.psb";
+		checkCompressionFile<uint16_t>(combined_path, 0, 32895, 65535);
+	}
+}
+
+
+TEST_CASE("Decompress 32 bit file with ZIP Prediction compression")
+{
+	// We count all 4 variations of this as the same test case
+	SUBCASE("PSD")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_32bit.psd";
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+	}
+	SUBCASE("PSB")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_32bit.psb";
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+	}
+	SUBCASE("MaximizeCompatibilityOff_PSD")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_32bit.psd";
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+	}
+	SUBCASE("MaximizeCompatibilityOff_PSB")
+	{
+		std::filesystem::path combined_path = std::filesystem::current_path();
+		combined_path += "\\documents\\Compression\\Compression_ZipPrediction_MaximizeCompatibilityOff_32bit.psb";
+		checkCompressionFile<float32_t>(combined_path, 0.0f, 0.501953f, 1.0f);
+	}
+}

--- a/PhotoshopTest/src/TestCompression/Utility.cpp
+++ b/PhotoshopTest/src/TestCompression/Utility.cpp
@@ -1,0 +1,186 @@
+#include "Utility.h"
+
+#include "Macros.h"
+#include "PhotoshopFile/PhotoshopFile.h"
+#include "Struct/TaggedBlock.h"
+#include "Enum.h"
+
+#include <vector>
+#include <filesystem>
+#include <type_traits>
+#include <optional>
+
+// Explicitly instantiate these templates
+template void checkCompressionFile<uint8_t>(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val);
+template void checkCompressionFile<uint16_t>(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val);
+template void checkCompressionFile<float32_t>(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val);
+
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+template <typename T>
+void checkCompressionFile(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val)
+{
+	// This document is 64x64 pixels, 8 bit and its channels are all compressed using RLE
+	// There are 5 layers in total which each represent different types of data
+	//		- "LayerRed":			Layer that is entirely red, we expect the red channel to be entirely white (255) while the rest is 0
+	//		- "LayerGreen":			Same as above but entirely green
+	//		- "LayerBlue":			Same as above but entirely blue
+	//		- "LayerFirstRowRed":	The entire layer is black except for the first row which is red (255, 0, 0). We expect the data to reflect this
+	//		- "Layer_R255_G128_B0":	The layer has the R, G and B values indicated in the layer name across the whole document
+
+	NAMESPACE_PSAPI::File file(inputPath);
+	NAMESPACE_PSAPI::PhotoshopFile document;
+	bool didParse = document.read(file);
+
+	// 16 and 32 bit files store their layerInformation in the additional tagged blocks
+	NAMESPACE_PSAPI::LayerInfo& layerInformation = document.m_LayerMaskInfo.m_LayerInfo;;
+	if (sizeof(T) == 1)
+	{
+		// No need to reassign
+	}
+	else if (sizeof(T) == 2)
+	{
+		REQUIRE(document.m_LayerMaskInfo.m_AdditionalLayerInfo.has_value());
+		auto& additionalLayerInfo = document.m_LayerMaskInfo.m_AdditionalLayerInfo.value();
+		auto lr16TaggedBlock = additionalLayerInfo.getTaggedBlock<NAMESPACE_PSAPI::TaggedBlock::Lr16>(NAMESPACE_PSAPI::Enum::TaggedBlockKey::Lr16);
+		REQUIRE(lr16TaggedBlock.has_value());
+		layerInformation = lr16TaggedBlock.value()->m_Data;
+	}
+	else if (sizeof(T) == 4)
+	{
+		REQUIRE(document.m_LayerMaskInfo.m_AdditionalLayerInfo.has_value());
+		auto& additionalLayerInfo = document.m_LayerMaskInfo.m_AdditionalLayerInfo.value();
+		auto lr32TaggedBlock = additionalLayerInfo.getTaggedBlock<NAMESPACE_PSAPI::TaggedBlock::Lr32>(NAMESPACE_PSAPI::Enum::TaggedBlockKey::Lr32);
+		REQUIRE(lr32TaggedBlock.has_value());
+		layerInformation = lr32TaggedBlock.value()->m_Data;
+	}
+	else
+	{
+		REQUIRE(false);
+	}
+
+	SUBCASE("Check Layer Count is read correctly")
+	{
+		std::size_t layerRecordLength = layerInformation.m_LayerRecords.size();
+		std::size_t channelImageDataLength = layerInformation.m_ChannelImageData.size();
+
+		REQUIRE(layerRecordLength == 5);
+		REQUIRE(channelImageDataLength == 5);
+	}
+
+	SUBCASE("Check 'LayerRed'")
+	{
+		int layerIndex = layerInformation.getLayerIndex("LayerRed");
+
+		SUBCASE("Could find layer")
+		{
+			CHECK(layerIndex != -1);
+		}
+
+		SUBCASE("Channels are correct")
+		{
+
+			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
+
+			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
+			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
+			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
+			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+
+			CHECK(channel_r_index != -1);
+			CHECK(channel_g_index != -1);
+			CHECK(channel_b_index != -1);
+			CHECK(channel_a_index != -1);
+
+			std::vector<T> expected_r(64 * 64, one_val);
+			std::vector<T> expected_bg(64 * 64, zero_val);
+
+			// We could also extract directly using this signature and skip the step above
+			// channelImageData.extractImageData<T>(NAMESPACE_PSAPI::Enum::ChannelID::Red)
+			CHECK(channelImageData.extractImageData<T>(channel_r_index) == expected_r);
+			CHECK(channelImageData.extractImageData<T>(channel_g_index) == expected_bg);
+			CHECK(channelImageData.extractImageData<T>(channel_b_index) == expected_bg);
+			// Alpha channel is white
+			CHECK(channelImageData.extractImageData<T>(channel_a_index) == expected_r);
+
+		}
+	}
+
+	SUBCASE("Check 'LayerFirstRowRed'")
+	{
+		int layerIndex = layerInformation.getLayerIndex("LayerFirstRowRed");
+
+		SUBCASE("Could find layer")
+		{
+			CHECK(layerIndex != -1);
+		}
+
+		SUBCASE("Channels are correct")
+		{
+			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
+
+			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
+			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
+			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
+			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+
+			CHECK(channel_r_index != -1);
+			CHECK(channel_g_index != -1);
+			CHECK(channel_b_index != -1);
+			CHECK(channel_a_index != -1);
+
+			// Fill the first row with white values
+			std::vector<T> expected_r(64 * 64, zero_val);
+			for (int i = 0; i < 64; ++i)
+			{
+				expected_r[i] = one_val;
+			}
+			std::vector<T> expected_bg(64 * 64, zero_val);
+			std::vector<T> expected_a(64 * 64, one_val);
+
+			CHECK(channelImageData.extractImageData<T>(channel_r_index) == expected_r);
+			CHECK(channelImageData.extractImageData<T>(channel_g_index) == expected_bg);
+			CHECK(channelImageData.extractImageData<T>(channel_b_index) == expected_bg);
+			// Alpha channel is white
+			CHECK(channelImageData.extractImageData<T>(channel_a_index) == expected_a);
+		}
+	}
+
+	SUBCASE("Check 'Layer_R255_G128_B0'")
+	{
+		int layerIndex = layerInformation.getLayerIndex("Layer_R255_G128_B0");
+
+		SUBCASE("Could find layer")
+		{
+			CHECK(layerIndex != -1);
+		}
+
+		SUBCASE("Channels are correct")
+		{
+			NAMESPACE_PSAPI::ChannelImageData& channelImageData = layerInformation.m_ChannelImageData.at(layerIndex);
+
+			int channel_r_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Red);
+			int channel_g_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Green);
+			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
+			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
+
+			CHECK(channel_r_index != -1);
+			CHECK(channel_g_index != -1);
+			CHECK(channel_b_index != -1);
+			CHECK(channel_a_index != -1);
+
+			std::vector<T> expected_r(64 * 64, one_val);
+			std::vector<T> expected_g(64 * 64, val_128);
+			std::vector<T> expected_b(64 * 64, zero_val);
+
+
+			CHECK(channelImageData.extractImageData<T>(channel_r_index) == expected_r);
+			CHECK(channelImageData.extractImageData<T>(channel_g_index) == expected_g);
+			CHECK(channelImageData.extractImageData<T>(channel_b_index) == expected_b);
+			// Alpha channel is white
+			CHECK(channelImageData.extractImageData<T>(channel_a_index) == expected_r);
+		}
+	}
+
+	CHECK(didParse);
+}

--- a/PhotoshopTest/src/TestCompression/Utility.cpp
+++ b/PhotoshopTest/src/TestCompression/Utility.cpp
@@ -15,6 +15,18 @@ template void checkCompressionFileImpl<uint8_t>(NAMESPACE_PSAPI::LayerInfo& laye
 template void checkCompressionFileImpl<uint16_t>(NAMESPACE_PSAPI::LayerInfo& layerInformation, const double zero_val, const double val_128, const double one_val, const double red_zero_val);
 template void checkCompressionFileImpl<float32_t>(NAMESPACE_PSAPI::LayerInfo& layerInformation, const double zero_val, const double val_128, const double one_val, const double red_zero_val);
 
+
+// Neat little implementation by DzedCPT https://stackoverflow.com/questions/41160846/test-floating-point-stdvector-with-c-catch
+// That only adds one assertion for each vec rather than for each CHECK
+#define CHECK_VEC_ALMOST_EQUAL(x, y) \
+    REQUIRE(x.size() == y.size()); \
+    for (size_t i = 0; i < x.size(); ++i) { \
+		if (x[i] != doctest::Approx(y[i])) { \
+			CHECK(x[i] == doctest::Approx(y[i])); \
+		} \
+    }
+
+
 // ---------------------------------------------------------------------------------------------------------------------
 // ---------------------------------------------------------------------------------------------------------------------
 template <typename T>
@@ -44,7 +56,7 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 
 		SUBCASE("Could find layer")
 		{
-			CHECK(layerIndex != -1);
+			REQUIRE(layerIndex != -1);
 		}
 
 		SUBCASE("Channels are correct")
@@ -57,10 +69,10 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
 			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
 
-			CHECK(channel_r_index != -1);
-			CHECK(channel_g_index != -1);
-			CHECK(channel_b_index != -1);
-			CHECK(channel_a_index != -1);
+			REQUIRE(channel_r_index != -1);
+			REQUIRE(channel_g_index != -1);
+			REQUIRE(channel_b_index != -1);
+			REQUIRE(channel_a_index != -1);
 
 			// We could also extract directly using this signature and skip the step above
 			// channelImageData.extractImageData<T>(NAMESPACE_PSAPI::Enum::ChannelID::Red)
@@ -73,11 +85,11 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 			std::vector<T> expected_bg(64 * 64, red_zero_val);
 
 			
-			CHECK(channel_r == expected_r);
-			CHECK(channel_b == expected_bg);
-			CHECK(channel_g == expected_bg);
+			CHECK_VEC_ALMOST_EQUAL(channel_r, expected_r);
+			CHECK_VEC_ALMOST_EQUAL(channel_b, expected_bg);
+			CHECK_VEC_ALMOST_EQUAL(channel_g, expected_bg);
 			// Alpha channel is white
-			CHECK(channel_a == expected_r);
+			CHECK_VEC_ALMOST_EQUAL(channel_a, expected_r);
 
 		}
 	}
@@ -88,7 +100,7 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 
 		SUBCASE("Could find layer")
 		{
-			CHECK(layerIndex != -1);
+			REQUIRE(layerIndex != -1);
 		}
 
 		SUBCASE("Channels are correct")
@@ -100,10 +112,10 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
 			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
 
-			CHECK(channel_r_index != -1);
-			CHECK(channel_g_index != -1);
-			CHECK(channel_b_index != -1);
-			CHECK(channel_a_index != -1);
+			REQUIRE(channel_r_index != -1);
+			REQUIRE(channel_g_index != -1);
+			REQUIRE(channel_b_index != -1);
+			REQUIRE(channel_a_index != -1);
 
 			// We could also extract directly using this signature and skip the step above
 			// channelImageData.extractImageData<T>(NAMESPACE_PSAPI::Enum::ChannelID::Red)
@@ -125,11 +137,11 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 			}
 			std::vector<T> expected_a(64 * 64, one_val);
 
-			CHECK(channel_r == expected_r);
-			CHECK(channel_b == expected_bg);
-			CHECK(channel_g == expected_bg);
+			CHECK_VEC_ALMOST_EQUAL(channel_r, expected_r);
+			CHECK_VEC_ALMOST_EQUAL(channel_b, expected_bg);
+			CHECK_VEC_ALMOST_EQUAL(channel_g, expected_bg);
 			// Alpha channel is white
-			CHECK(channel_a == expected_a);
+			CHECK_VEC_ALMOST_EQUAL(channel_a, expected_a);
 		}
 	}
 
@@ -139,7 +151,7 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 
 		SUBCASE("Could find layer")
 		{
-			CHECK(layerIndex != -1);
+			REQUIRE(layerIndex != -1);
 		}
 
 		SUBCASE("Channels are correct")
@@ -151,21 +163,28 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 			int channel_b_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::Blue);
 			int channel_a_index = channelImageData.getChannelIndex(NAMESPACE_PSAPI::Enum::ChannelID::TransparencyMask);
 
-			CHECK(channel_r_index != -1);
-			CHECK(channel_g_index != -1);
-			CHECK(channel_b_index != -1);
-			CHECK(channel_a_index != -1);
+			// We could also extract directly using this signature and skip the step above
+			// channelImageData.extractImageData<T>(NAMESPACE_PSAPI::Enum::ChannelID::Red)
+			std::vector<T> channel_r = channelImageData.extractImageData<T>(channel_r_index);
+			std::vector<T> channel_g = channelImageData.extractImageData<T>(channel_g_index);
+			std::vector<T> channel_b = channelImageData.extractImageData<T>(channel_b_index);
+			std::vector<T> channel_a = channelImageData.extractImageData<T>(channel_a_index);
+
+			REQUIRE(channel_r_index != -1);
+			REQUIRE(channel_g_index != -1);
+			REQUIRE(channel_b_index != -1);
+			REQUIRE(channel_a_index != -1);
 
 			std::vector<T> expected_r(64 * 64, one_val);
 			std::vector<T> expected_g(64 * 64, val_128);
 			std::vector<T> expected_b(64 * 64, zero_val);
 
 
-			CHECK(channelImageData.extractImageData<T>(channel_r_index) == expected_r);
-			CHECK(channelImageData.extractImageData<T>(channel_g_index) == expected_g);
-			CHECK(channelImageData.extractImageData<T>(channel_b_index) == expected_b);
+			CHECK_VEC_ALMOST_EQUAL(channel_r, expected_r);
+			CHECK_VEC_ALMOST_EQUAL(channel_g, expected_g);
+			CHECK_VEC_ALMOST_EQUAL(channel_b, expected_b);
 			// Alpha channel is white
-			CHECK(channelImageData.extractImageData<T>(channel_a_index) == expected_r);
+			CHECK_VEC_ALMOST_EQUAL(channel_a, expected_r);
 		}
 	}
 

--- a/PhotoshopTest/src/TestCompression/Utility.h
+++ b/PhotoshopTest/src/TestCompression/Utility.h
@@ -2,9 +2,20 @@
 
 #include "doctest.h"
 
+#include "PhotoshopFile/LayerAndMaskInformation.h"
+#include "Macros.h"
+
 #include <filesystem>
 
-// function to read the files found in the compression folder with which we can continuously retest the same layer structure as well as easily expand
-// on further test case
+
+// Implementation of the above function. This specialization is necessary due to the way in which we access the layerinfo for 8, 16 and 32 bit files
 template <typename T>
-inline void checkCompressionFile(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val);
+void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, const double zero_val, const double val_128, const double one_val, const double red_zero_val);
+
+
+// function to read the files found in the compression folder with which we can continuously retest the same layer structure as well as easily expand
+// on further test case.
+// Note the red_zero_val parameter here. This is not a mistake. When saving out a completely red channel in 16-bit mode the other channels will actually be 
+// of a value of 2. This is only for completely red pixels and I am unsure why this is the case but we do need the specialization
+template <typename T>
+void checkCompressionFile(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val, const double red_zero_val);

--- a/PhotoshopTest/src/TestCompression/Utility.h
+++ b/PhotoshopTest/src/TestCompression/Utility.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "doctest.h"
+
+#include <filesystem>
+
+// function to read the files found in the compression folder with which we can continuously retest the same layer structure as well as easily expand
+// on further test case
+template <typename T>
+inline void checkCompressionFile(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val);

--- a/PhotoshopTest/src/main.cpp
+++ b/PhotoshopTest/src/main.cpp
@@ -11,7 +11,6 @@
 #include <vector>
 #include <memory>
 
-
 // This is the data we run all the whole-file tests on. Keep in mind that this does not necessarily cover all of the documents found in /documents
 // as some cover very specific individual sections such as /documents/Compression
 std::vector<std::filesystem::path> relPaths =
@@ -53,6 +52,7 @@ std::vector<std::filesystem::path> relPaths =
 	"\\documents\\SingleLayer\\SingleLayer_32bit.psb",
 	"\\documents\\SingleLayer\\SingleLayer_32bit_MaximizeCompatibilityOff.psd",
 	"\\documents\\SingleLayer\\SingleLayer_32bit_MaximizeCompatibilityOff.psb",*/
+	"\\documents\\tmp.psb"
 };
 
 
@@ -64,6 +64,9 @@ int main()
 	{
 		std::filesystem::path combined_path = currentDirectory;
 		combined_path += path;
+
+		PSAPI_LOG("Main", "Started Parsing of file %s", combined_path.string().c_str())
+
 		NAMESPACE_PSAPI::File file(combined_path);
 		std::unique_ptr<NAMESPACE_PSAPI::PhotoshopFile> document = std::make_unique<NAMESPACE_PSAPI::PhotoshopFile>();
 		bool didParse = document->read(file);

--- a/PhotoshopTest/src/main.cpp
+++ b/PhotoshopTest/src/main.cpp
@@ -26,7 +26,7 @@ std::vector<std::filesystem::path> relPaths =
 	"\\documents\\Grayscale\\Grayscale_16bit.psd",
 	"\\documents\\Grayscale\\Grayscale_16bit.psb",
 	"\\documents\\Grayscale\\Grayscale_32bit.psd",
-	"\\documents\\Grayscale\\Grayscale_32bit.psb",*/
+	"\\documents\\Grayscale\\Grayscale_32bit.psb",
 
 	"\\documents\\Groups\\Groups_8bit.psd",
 	"\\documents\\Groups\\Groups_8bit.psb",
@@ -52,7 +52,7 @@ std::vector<std::filesystem::path> relPaths =
 	"\\documents\\SingleLayer\\SingleLayer_32bit.psd",
 	"\\documents\\SingleLayer\\SingleLayer_32bit.psb",
 	"\\documents\\SingleLayer\\SingleLayer_32bit_MaximizeCompatibilityOff.psd",
-	"\\documents\\SingleLayer\\SingleLayer_32bit_MaximizeCompatibilityOff.psb",
+	"\\documents\\SingleLayer\\SingleLayer_32bit_MaximizeCompatibilityOff.psb",*/
 };
 
 


### PR DESCRIPTION
Tagged blocks before were a bit cumbersome to work with as, due to its dependency on LayerInfo, we had issues with recursive includes.

This has been solved in two separate steps:

1. TaggedBlocks are now stored in a `TaggedBlockStorage` struct which doesnt have any information about what the tagged block actually are
2. `AdditionalLayerInfo` was moved to a separate file that then includes TaggedBlockStorage leading the include tree to look something like this
```
- LayerAndMaskInformation.h
   - AdditionalLayerInfo.h
      - TaggedBlockStorage.h
- TaggedBlock.h
   - LayerAndMaskInformation.h
```

This way we stopped the recursive includes as TaggedBlockStorage is separated from the TaggedBlocks themselves