### PR TITLE
Change Logging macro signature

### DIFF
--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.cpp
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.cpp
@@ -65,7 +65,7 @@ Layer<T>::Layer(const LayerRecord& layerRecord, ChannelImageData& channelImageDa
 			}
 			else
 			{
-				PSAPI_LOG_ERROR("Layer", "Unable to cast mask to ImageChannel")
+				PSAPI_LOG_ERROR("Layer", "Unable to cast mask to ImageChannel");
 			}
 			channelPtr = nullptr;
 

--- a/PhotoshopAPI/src/LayeredFile/LayeredFile.cpp
+++ b/PhotoshopAPI/src/LayeredFile/LayeredFile.cpp
@@ -122,7 +122,7 @@ std::shared_ptr<Layer<T>> LayeredFile<T>::findLayer(std::string path) const
 			return LayeredFileImpl::findLayerRecurse(layer, segments, 1);
 		}
 	}
-	PSAPI_LOG_WARNING("LayeredFile", "Unable to find layer path %s", path.c_str())
+	PSAPI_LOG_WARNING("LayeredFile", "Unable to find layer path %s", path.c_str());
 	return nullptr;
 }
 
@@ -156,8 +156,8 @@ std::vector<std::shared_ptr<Layer<T>>> LayeredFile<T>::generateFlatLayers(std::o
 		std::reverse(flatLayers.begin(), flatLayers.end());
 		return flatLayers;
 	}
-	PSAPI_LOG_ERROR("LayeredFile", "Invalid layer order specified, only accepts forward or reverse")
-		return std::vector<std::shared_ptr<Layer<T>>>();
+	PSAPI_LOG_ERROR("LayeredFile", "Invalid layer order specified, only accepts forward or reverse");
+	return std::vector<std::shared_ptr<Layer<T>>>();
 }
 
 
@@ -171,7 +171,7 @@ std::vector<std::shared_ptr<Layer<T>>> LayeredFileImpl::buildLayerHierarchy(std:
 
 	if (layerRecords->size() != channelImageData->size())
 	{
-		PSAPI_LOG_ERROR("LayeredFile", "LayerRecords Size does not match channelImageDataSize. File appears to be corrupted")
+		PSAPI_LOG_ERROR("LayeredFile", "LayerRecords Size does not match channelImageDataSize. File appears to be corrupted");
 	}
 
 	// 16 and 32 bit files store their layer records in the additional layer information section. We must therefore overwrite our previous results
@@ -194,7 +194,7 @@ std::vector<std::shared_ptr<Layer<T>>> LayeredFileImpl::buildLayerHierarchy(std:
 		}
 		else
 		{
-			PSAPI_LOG_ERROR("LayeredFile", "PhotoshopFile does not seem to contain a Lr16 or Lr32 Tagged block which would hold layer information")
+			PSAPI_LOG_ERROR("LayeredFile", "PhotoshopFile does not seem to contain a Lr16 or Lr32 Tagged block which would hold layer information");
 		}
 	}
 
@@ -449,10 +449,10 @@ std::shared_ptr<Layer<T>> LayeredFileImpl::findLayerRecurse(std::shared_ptr<Laye
 				return LayeredFileImpl::findLayerRecurse(layerPtr, path, index+1);
 			}
 		}
-		PSAPI_LOG_WARNING("LayeredFile", "Failed to find layer '%s' based on the path", path[index].c_str())
+		PSAPI_LOG_WARNING("LayeredFile", "Failed to find layer '%s' based on the path", path[index].c_str());
 		return nullptr;
 	}
-	PSAPI_LOG_WARNING("LayeredFile", "Provided parent layer is not a grouplayer and can therefore not have children")
+	PSAPI_LOG_WARNING("LayeredFile", "Provided parent layer is not a grouplayer and can therefore not have children");
 	return nullptr;
 }
 

--- a/PhotoshopAPI/src/LayeredFile/Util/GenerateLayerMaskInfo.cpp
+++ b/PhotoshopAPI/src/LayeredFile/Util/GenerateLayerMaskInfo.cpp
@@ -19,7 +19,7 @@ PSAPI_NAMESPACE_BEGIN
 template <typename T>
 LayerAndMaskInformation generateLayerMaskInfo(LayeredFile<T>& layeredFile, const FileHeader& header)
 {
-	PSAPI_LOG_ERROR("LayeredFile", "Cannot construct layer and mask information section if type is not uint8_t, uint16_t or float32_t")
+	PSAPI_LOG_ERROR("LayeredFile", "Cannot construct layer and mask information section if type is not uint8_t, uint16_t or float32_t");
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/PhotoshopAPI/src/PhotoshopFile/ColorModeData.cpp
+++ b/PhotoshopAPI/src/PhotoshopFile/ColorModeData.cpp
@@ -80,7 +80,7 @@ void ColorModeData::write(File& document, FileHeader& header)
 		// This check is mostly for internal checks as we declare the data here
 		if (data.size() != 112u)
 		{
-			PSAPI_LOG_ERROR("ChannelImageData", "Data size was not 112")
+			PSAPI_LOG_ERROR("ChannelImageData", "Data size was not 112");
 		}
 		m_Data = data;
 		WriteBinaryData<uint32_t>(document, data.size());
@@ -93,7 +93,7 @@ void ColorModeData::write(File& document, FileHeader& header)
 		if (m_Data.size() > 0)
 		{
 			PSAPI_LOG_ERROR("ColorModeData", "Invalid size for ColorMode data detected, only indexed colours have data in this \
-				section (32-bit files get handled internally)")
+				section (32-bit files get handled internally)");
 		}
 		m_Size = 4u;
 		WriteBinaryData<uint32_t>(document, 0u);

--- a/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.cpp
+++ b/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.cpp
@@ -344,7 +344,7 @@ void LayerRecords::LayerMaskData::read(File& document)
 
 	if (toRead < 0 || toRead > 2)
 	{
-		PSAPI_LOG_WARNING("LayerMaskData", "Expected either 0 or 2 padding bytes, got %i instead", toRead)
+		PSAPI_LOG_WARNING("LayerMaskData", "Expected either 0 or 2 padding bytes, got %i instead", toRead);
 	}
 
 	document.skip(toRead);
@@ -363,7 +363,7 @@ void LayerRecords::LayerMaskData::write(File& document) const
 	
 	if (m_LayerMask.has_value() && m_VectorMask.has_value())
 	{
-		PSAPI_LOG_WARNING("LayerMaskData", "Having two masks is currently unsupported by the PhotoshopAPI, currently only pixel masks are supported.")
+		PSAPI_LOG_WARNING("LayerMaskData", "Having two masks is currently unsupported by the PhotoshopAPI, currently only pixel masks are supported.");
 	}
 	else if (m_LayerMask.has_value())
 	{
@@ -469,8 +469,8 @@ void LayerRecords::LayerBlendingRanges::write(File& document) const
 
 	if (m_SourceRanges.size() != m_DestinationRanges.size()) [[unlikely]]
 	{
-		PSAPI_LOG_ERROR("LayerBlendingRanges", "Source and Destination ranges must have the exact same size, source range size : %i, destination range size : %i",
-			m_SourceRanges.size(), m_DestinationRanges.size())
+			PSAPI_LOG_ERROR("LayerBlendingRanges", "Source and Destination ranges must have the exact same size, source range size : %i, destination range size : %i",
+				m_SourceRanges.size(), m_DestinationRanges.size());
 	}
 
 	for (int i = 0; i < m_SourceRanges.size(); ++i)
@@ -551,7 +551,7 @@ uint64_t LayerRecord::calculateSize(std::shared_ptr<FileHeader> header /*= nullp
 {
 	if (!header)
 	{
-		PSAPI_LOG_ERROR("LayerRecord", "calculateSize() function requires the header to be passed")
+		PSAPI_LOG_ERROR("LayerRecord", "calculateSize() function requires the header to be passed");
 	}
 
 	uint64_t size = 0u;
@@ -596,7 +596,7 @@ void LayerRecord::read(File& document, const FileHeader& header, const uint64_t 
 	m_ChannelCount = ReadBinaryData<uint16_t>(document);
 	if (m_ChannelCount > 56)
 	{
-		PSAPI_LOG_ERROR("LayerRecord", "A Photoshop document cannot have more than 56 channels at once")
+		PSAPI_LOG_ERROR("LayerRecord", "A Photoshop document cannot have more than 56 channels at once");
 	}
 	m_ChannelInformation.reserve(m_ChannelCount);
 
@@ -617,7 +617,7 @@ void LayerRecord::read(File& document, const FileHeader& header, const uint64_t 
 			break;
 		default:
 			int16_t index = ReadBinaryData<uint16_t>(document);
-			PSAPI_LOG_WARNING("LayerRecord", "Currently unsupported ColorMode encountered, storing ChannelID::Custom")
+			PSAPI_LOG_WARNING("LayerRecord", "Currently unsupported ColorMode encountered, storing ChannelID::Custom");
 				channelInfo.m_ChannelID = { Enum::ChannelID::Custom, index };
 			break;
 		}
@@ -635,7 +635,7 @@ void LayerRecord::read(File& document, const FileHeader& header, const uint64_t 
 	if (signature != Signature("8BIM"))
 	{
 		PSAPI_LOG_ERROR("LayerRecord", "Signature does not match '8BIM', got '%s' instead",
-			uint32ToString(signature.m_Value).c_str())
+			uint32ToString(signature.m_Value).c_str());
 	}
 	m_Size += 4u;
 	
@@ -709,7 +709,7 @@ void LayerRecord::write(File& document, const FileHeader& header, std::vector<La
 
 	if (channelInfos.size() != m_ChannelCount)
 		PSAPI_LOG_ERROR("LayerRecord", "The provided channelInfo vec does not have the same amount of channels as m_ChanneCount, expected %i but got %i instead",
-			m_ChannelCount, channelInfos.size())
+			m_ChannelCount, channelInfos.size());
 	for (const auto& info : channelInfos)
 	{
 		WriteBinaryData<int16_t>(document, info.m_ChannelID.index);
@@ -719,13 +719,13 @@ void LayerRecord::write(File& document, const FileHeader& header, std::vector<La
 	WriteBinaryData<uint32_t>(document, Signature("8BIM").m_Value);
 	std::optional<std::string> blendModeStr = Enum::getBlendMode<Enum::BlendMode, std::string>(m_BlendMode);
 	if (!blendModeStr.has_value())
-		PSAPI_LOG_ERROR("LayerRecord", "Could not identify a blend mode string from the given key")
+		PSAPI_LOG_ERROR("LayerRecord", "Could not identify a blend mode string from the given key");
 	WriteBinaryData<uint32_t>(document, Signature(blendModeStr.value()).m_Value);
 
 
 	WriteBinaryData<uint8_t>(document, m_Opacity);
 	if (m_Clipping > 1)
-		PSAPI_LOG_ERROR("LayerRecord", "'Clipping' variable must be 0 or 1, not %u", m_Clipping)
+		PSAPI_LOG_ERROR("LayerRecord", "'Clipping' variable must be 0 or 1, not %u", m_Clipping);
 	WriteBinaryData<uint8_t>(document, m_Clipping);
 
 	WriteBinaryData<uint8_t>(document, m_BitFlags.getFlags());
@@ -794,7 +794,7 @@ uint64_t ChannelImageData::calculateSize(std::shared_ptr<FileHeader> header /*= 
 {
 	uint64_t size = 0u;
 
-	PSAPI_LOG_WARNING("ChannelImageData", "Unable to compute size of channelImageData due to the size only being known at export time, please refrain from using this function")
+	PSAPI_LOG_WARNING("ChannelImageData", "Unable to compute size of channelImageData due to the size only being known at export time, please refrain from using this function");
 
 	return size;
 }
@@ -812,7 +812,7 @@ uint64_t ChannelImageData::estimateSize(const FileHeader& header, const uint16_t
 		ImageChannel<T>* imageChannel = dynamic_cast<ImageChannel<T>*>(channel.get());
 		if (!imageChannel)
 		{
-			PSAPI_LOG_WARNING("ChannelImageData", "Unable to read data from channel '%i'", channel->m_ChannelID.id)
+			PSAPI_LOG_WARNING("ChannelImageData", "Unable to read data from channel '%i'", channel->m_ChannelID.id);
 			continue;
 		}
 
@@ -872,7 +872,7 @@ std::vector<std::vector<uint8_t>> ChannelImageData::compressData(const FileHeade
 		std::unique_ptr<BaseImageChannel> imageChannelPtr = std::move(m_ImageData[i]);
 		if (imageChannelPtr == nullptr) [[unlikely]]
 		{
-			PSAPI_LOG_WARNING("ChannelImageData", "Channel %i no longer contains any data, was it extracted beforehand?", i)
+				PSAPI_LOG_WARNING("ChannelImageData", "Channel %i no longer contains any data, was it extracted beforehand?", i);
 			auto emptyVec = std::vector<std::vector<uint8_t>>();
 			return emptyVec;
 		}
@@ -897,7 +897,7 @@ std::vector<std::vector<uint8_t>> ChannelImageData::compressData(const FileHeade
 		}
 		else [[unlikely]]
 		{
-			PSAPI_LOG_ERROR("ChannelImageData", "Unable to extract image data for channel at index %i", i)
+			PSAPI_LOG_ERROR("ChannelImageData", "Unable to extract image data for channel at index %i", i);
 			auto emptyVec = std::vector<std::vector<uint8_t>>();
 			return emptyVec;
 		}
@@ -996,7 +996,7 @@ void ChannelImageData::write(File& document, const std::vector<std::vector<uint8
 
 		std::optional<uint16_t> compressionCode = Enum::getCompression<Enum::Compression, uint16_t>(channelCompression[i]);
 		if (!compressionCode.has_value()) [[unlikely]]
-			PSAPI_LOG_ERROR("LayerInfo", "Could not find a match for the given compression codec")
+			PSAPI_LOG_ERROR("LayerInfo", "Could not find a match for the given compression codec");
 
 		WriteBinaryData<uint16_t>(document, compressionCode.value());
 		WriteBinaryArray<uint8_t>(document, compressedChannelData[i]);
@@ -1010,7 +1010,7 @@ uint64_t LayerInfo::calculateSize(std::shared_ptr<FileHeader> header /*= nullptr
 {
 	uint64_t size = 0u;
 
-	PSAPI_LOG_WARNING("LayerInfo", "Unable to compute size of LayerInfo due to the size only being known upon compressing of the image channels, please refrain from using this function")
+	PSAPI_LOG_WARNING("LayerInfo", "Unable to compute size of LayerInfo due to the size only being known upon compressing of the image channels, please refrain from using this function");
 
 	return size;
 }
@@ -1108,7 +1108,7 @@ void LayerInfo::read(File& document, const FileHeader& header, const uint64_t of
 		// Check that the skipped bytes are within the amount needed to pad a LayerInfo section
 		if (toSkip < -4 || toSkip > 4)
 		{
-			PSAPI_LOG_ERROR("LayerInfo", "Tried skipping bytes larger than the padding of the section: %i", toSkip)
+			PSAPI_LOG_ERROR("LayerInfo", "Tried skipping bytes larger than the padding of the section: %i", toSkip);
 		}
 		document.setOffset(document.getOffset() + toSkip);
 	}
@@ -1144,7 +1144,7 @@ void LayerInfo::write(File& document, const FileHeader& header, const uint16_t p
 
 	if (m_LayerRecords.size() != m_ChannelImageData.size()) [[unlikely]]
 	{
-		PSAPI_LOG_ERROR("LayerInfo", "The number of layer records and channel image data instances mismatch, got %i lrRecords and %i channelImgData", m_LayerRecords.size(), m_ChannelImageData.size())
+			PSAPI_LOG_ERROR("LayerInfo", "The number of layer records and channel image data instances mismatch, got %i lrRecords and %i channelImgData", m_LayerRecords.size(), m_ChannelImageData.size());
 	}
 	// The nesting here indicates Layers/Channels/ImgData
 	std::vector<std::vector<std::vector<uint8_t>>> compressedData;
@@ -1169,7 +1169,7 @@ void LayerInfo::write(File& document, const FileHeader& header, const uint16_t p
 		}
 		else
 		{
-			PSAPI_LOG_ERROR("LayerInfo", "Unsupported BitDepth encountered, currently only 8-, 16- and 32-bit files are supported")
+			PSAPI_LOG_ERROR("LayerInfo", "Unsupported BitDepth encountered, currently only 8-, 16- and 32-bit files are supported");
 		}
 		channelInfos.push_back(lrChannelInfo);
 		channelCompression.push_back(lrCompression);
@@ -1235,7 +1235,7 @@ uint64_t LayerAndMaskInformation::calculateSize(std::shared_ptr<FileHeader> head
 {
 	uint64_t size = 0u;
 
-	PSAPI_LOG_WARNING("LayerAndMaskInformation", "Unable to compute size of LayerAndMaskInformation due to the size only being known upon compressing of the image channels, please refrain from using this function")
+	PSAPI_LOG_WARNING("LayerAndMaskInformation", "Unable to compute size of LayerAndMaskInformation due to the size only being known upon compressing of the image channels, please refrain from using this function");
 
 	return size;
 }
@@ -1264,7 +1264,7 @@ void LayerAndMaskInformation::read(File& document, const FileHeader& header, con
 		{
 			PSAPI_LOG_ERROR("LayerAndMaskInformation", "Layer Info read an incorrect amount of bytes from the document, expected an offset of %" PRIu64 ", but got %" PRIu64 " instead.",
 				m_Offset + m_LayerInfo.m_Size + SwapPsdPsb<uint32_t, uint64_t>(header.m_Version),
-				document.getOffset())
+				document.getOffset());
 		}
 	}
 	// Parse Global Layer Mask Info

--- a/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.h
+++ b/PhotoshopAPI/src/PhotoshopFile/LayerAndMaskInformation.h
@@ -288,7 +288,7 @@ struct ChannelImageData : public FileSection
 		std::unique_ptr<BaseImageChannel> imageChannelPtr = std::move(m_ImageData.at(index));
 		if (imageChannelPtr == nullptr)
 		{
-			PSAPI_LOG_WARNING("ChannelImageData", "Channel %i no longer contains any data, was it extracted beforehand?", index)
+			PSAPI_LOG_WARNING("ChannelImageData", "Channel %i no longer contains any data, was it extracted beforehand?", index);
 			auto emptyVec = std::vector<T>();
 			return emptyVec;
 		}
@@ -300,7 +300,7 @@ struct ChannelImageData : public FileSection
 		}
 		else
 		{
-			PSAPI_LOG_ERROR("ChannelImageData", "Unable to extract image data for channel at index %i", index)
+			PSAPI_LOG_ERROR("ChannelImageData", "Unable to extract image data for channel at index %i", index);
 			auto emptyVec = std::vector<T>();
 			return emptyVec;
 		}
@@ -329,7 +329,7 @@ struct ChannelImageData : public FileSection
 		}
 		else
 		{
-			PSAPI_LOG_ERROR("ChannelImageData", "Unable to extract image data for channel at index %i", index)
+			PSAPI_LOG_ERROR("ChannelImageData", "Unable to extract image data for channel at index %i", index);
 			return std::vector<T>();			
 		}
 	}

--- a/PhotoshopAPI/src/Util/Compression/RLE.h
+++ b/PhotoshopAPI/src/Util/Compression/RLE.h
@@ -209,7 +209,7 @@ std::vector<T> DecompressRLE(ByteStream& stream, uint64_t offset, const FileHead
     {
         PSAPI_LOG_ERROR("DecompressRLE", "Size of compressed data is not what was expected. Expected: %" PRIu64 " but got %" PRIu64 " instead",
             dataSize,
-            scanlineTotalSize)
+            scanlineTotalSize);
     }
 
 	// Read the data without converting from BE to native as we need to decompress first
@@ -225,9 +225,9 @@ std::vector<T> DecompressRLE(ByteStream& stream, uint64_t offset, const FileHead
 
     if (bitShiftedData.size() != static_cast<uint64_t>(width) * static_cast<uint64_t>(height))
     {
-        PSAPI_LOG_ERROR("DecompressRLE", "Size of decompressed data is not what was expected. Expected: %" PRIu64 " but got %" PRIu64 " instead", 
+        PSAPI_LOG_ERROR("DecompressRLE", "Size of decompressed data is not what was expected. Expected: %" PRIu64 " but got %" PRIu64 " instead",
             static_cast<uint64_t>(width) * static_cast<uint64_t>(height),
-            bitShiftedData.size())
+            bitShiftedData.size());
     }
 	
 	return bitShiftedData;
@@ -267,7 +267,7 @@ std::vector<uint8_t> CompressRLE(std::vector<T>& uncompressedData, const FileHea
         {
             if (scanlineSize > (std::numeric_limits<uint16_t>::max)()) [[unlikely]]
 			{
-				PSAPI_LOG_ERROR("CompressRLE", "Scanline sizes cannot exceed the numeric limits of 16-bit values when writing a PSD file")
+                PSAPI_LOG_ERROR("CompressRLE", "Scanline sizes cannot exceed the numeric limits of 16-bit values when writing a PSD file");
 			}
             uint16_t scanlineSizeu16 = static_cast<uint16_t>(scanlineSize);
             scanlineSizeu16 = endianEncodeBE(scanlineSizeu16);

--- a/PhotoshopAPI/src/Util/Compression/ZIP.h
+++ b/PhotoshopAPI/src/Util/Compression/ZIP.h
@@ -37,7 +37,7 @@ namespace {
 
 		if (zng_inflateInit(&stream) != Z_OK)
 		{
-			PSAPI_LOG_ERROR("UnZip", "Inflate initialization failed")
+			PSAPI_LOG_ERROR("UnZip", "Inflate initialization failed");
 		}
 
 		// The size being fixed to exactly what we expect the decompressed data to be sized
@@ -50,12 +50,12 @@ namespace {
 
 		if (zng_inflate(&stream, Z_FINISH) != Z_STREAM_END)
 		{
-			PSAPI_LOG_ERROR("UnZip", "Inflate decompression failed")
+			PSAPI_LOG_ERROR("UnZip", "Inflate decompression failed");
 		}
 
 		if (zng_inflateEnd(&stream) != Z_OK)
 		{
-			PSAPI_LOG_ERROR("UnZip", "Inflate cleanup failed")
+			PSAPI_LOG_ERROR("UnZip", "Inflate cleanup failed");
 		}
 
 		return decompressedData;
@@ -82,7 +82,7 @@ namespace {
 
 		if (zng_deflateInit(&stream, Z_DEFAULT_COMPRESSION) != Z_OK)
 		{
-			PSAPI_LOG_ERROR("Zip", "Deflate init failed")
+			PSAPI_LOG_ERROR("Zip", "Deflate init failed");
 			return compressedData;
 		}
 
@@ -104,7 +104,7 @@ namespace {
 				if (result == Z_STREAM_ERROR)
 				{
 					zng_deflateEnd(&stream);
-					PSAPI_LOG_ERROR("Zip", "Unable to call deflate on the input data")
+					PSAPI_LOG_ERROR("Zip", "Unable to call deflate on the input data");
 					return compressedData;
 				}
 				size_t bytesUsed = buffer.size() - stream.avail_out;
@@ -113,11 +113,11 @@ namespace {
 		} while (flushState != Z_FINISH);
 		if (result != Z_STREAM_END)
 		{
-			PSAPI_LOG_ERROR("Zip", "Did not compress the whole buffer, there is still %i bytes remaining", stream.avail_in)
+			PSAPI_LOG_ERROR("Zip", "Did not compress the whole buffer, there is still %i bytes remaining", stream.avail_in);
 		}
 		if (zng_deflateEnd(&stream) != Z_OK)
 		{
-			PSAPI_LOG_ERROR("Zip", "Deflate cleanup failed")
+			PSAPI_LOG_ERROR("Zip", "Deflate cleanup failed");
 		}
 
 		return compressedData;

--- a/PhotoshopAPI/src/Util/Enum.h
+++ b/PhotoshopAPI/src/Util/Enum.h
@@ -379,7 +379,7 @@ namespace Enum
 	template<typename TKey, typename TValue>
 	inline std::optional<TValue> getBlendMode(TKey key)
 	{
-		PSAPI_LOG_ERROR("getBlendMode", "No overload for the specific search type found")
+		PSAPI_LOG_ERROR("getBlendMode", "No overload for the specific search type found");
 	}
 
 	template<>
@@ -545,7 +545,7 @@ namespace Enum
 	template<typename TKey, typename TValue>
 	inline std::optional<TValue> getTaggedBlockKey(TKey key)
 	{
-		PSAPI_LOG_ERROR("getTaggedBlockKey", "No overload for the specific search type found")
+		PSAPI_LOG_ERROR("getTaggedBlockKey", "No overload for the specific search type found");
 		return std::nullopt;
 	}
 
@@ -620,7 +620,7 @@ namespace Enum
 	template<typename TKey, typename TValue>
 	inline std::optional<TValue> getCompression(TKey key)
 	{
-		PSAPI_LOG_ERROR("getCompression", "No overload for the specific search type found")
+		PSAPI_LOG_ERROR("getCompression", "No overload for the specific search type found");
 	}
 
 	template<>
@@ -669,7 +669,7 @@ namespace Enum
 	template<typename TKey, typename TValue>
 	inline std::optional<TValue> getSectionDivider(TKey key)
 	{
-		PSAPI_LOG_ERROR("getSectionDivider", "No overload for the specific search type found")
+		PSAPI_LOG_ERROR("getSectionDivider", "No overload for the specific search type found");
 	}
 
 	template<>

--- a/PhotoshopAPI/src/Util/FileIO/Read.h
+++ b/PhotoshopAPI/src/Util/FileIO/Read.h
@@ -109,7 +109,7 @@ std::vector<T> ReadBinaryArray(File& document, uint64_t size)
 	if (size % sizeof(T) != 0)
 	{
 		PSAPI_LOG_ERROR("ReadBinaryArray", "Was given a binary size of %" PRIu64 " but that is not cleanly divisible by the size of the datatype T, which is %i",
-			size, sizeof(T))
+			size, sizeof(T));
 	}
 
 	std::vector<T> data(size / sizeof(T));
@@ -136,7 +136,7 @@ std::vector<T> ReadBinaryArray(File& document, uint64_t offset, uint64_t size)
 	if (size % sizeof(T) != 0)
 	{
 		PSAPI_LOG_ERROR("ReadBinaryArray", "Was given a binary size of %" PRIu64 " but that is not cleanly divisible by the size of the datatype T, which is %i",
-			size, sizeof(T))
+			size, sizeof(T));
 	}
 
 	std::vector<T> data(size / sizeof(T));
@@ -159,7 +159,7 @@ std::vector<T> ReadBinaryArray(ByteStream& stream, uint64_t size)
 	if (size % sizeof(T) != 0)
 	{
 		PSAPI_LOG_ERROR("ReadBinaryArray", "Was given a binary size of %" PRIu64 " but that is not cleanly divisible by the size of the datatype T, which is %i",
-			size, sizeof(T))
+			size, sizeof(T));
 	}
 
 	std::vector<T> data(size / sizeof(T));
@@ -185,7 +185,7 @@ std::vector<T> ReadBinaryArray(ByteStream& stream, uint64_t offset, uint64_t siz
 	if (size % sizeof(T) != 0)
 	{
 		PSAPI_LOG_ERROR("ReadBinaryArray", "Was given a binary size of %" PRIu64 " but that is not cleanly divisible by the size of the datatype T, which is %i",
-			size, sizeof(T))
+			size, sizeof(T));
 	}
 
 	std::vector<T> data(size / sizeof(T));

--- a/PhotoshopAPI/src/Util/FileIO/Write.h
+++ b/PhotoshopAPI/src/Util/FileIO/Write.h
@@ -36,7 +36,7 @@ void WriteBinaryDataVariadic(File& document, TPsb data, Enum::Version version)
 	if (version == Enum::Version::Psd)
 	{
 		if (data > (std::numeric_limits<TPsd>::max)()) [[unlikely]]
-			PSAPI_LOG_ERROR("WriteBinaryDataVariadic", "Value of data exceeds the numeric limits of the max value for type TPsd")
+			PSAPI_LOG_ERROR("WriteBinaryDataVariadic", "Value of data exceeds the numeric limits of the max value for type TPsd");
 		TPsd psdData = endianEncodeBE<TPsd>(static_cast<TPsd>(data));
 		std::span<uint8_t> dataSpan(reinterpret_cast<uint8_t*>(&psdData), sizeof(TPsd));
 		document.write(dataSpan);

--- a/PhotoshopAPI/src/Util/Logger.h
+++ b/PhotoshopAPI/src/Util/Logger.h
@@ -11,21 +11,23 @@
 #include <stdexcept>
 
 
-#define PSAPI_LOG(task, format, ...)						NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Info, task, format, __VA_ARGS__);
-#define PSAPI_LOG_ERROR(task, format, ...)					NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Error, task, format, __VA_ARGS__);
-#define PSAPI_LOG_WARNING(task, format, ...)				NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Warning, task, format, __VA_ARGS__);
-#define PSAPI_LOG_DEBUG(task, format, ...)					NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Debug, task, format, __VA_ARGS__);
+#define PSAPI_LOG(task, format, ...)						NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Info, task, format, __VA_ARGS__)
+#define PSAPI_LOG_ERROR(task, format, ...)					NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Error, task, format, __VA_ARGS__)
+#define PSAPI_LOG_WARNING(task, format, ...)				NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Warning, task, format, __VA_ARGS__)
+#define PSAPI_LOG_DEBUG(task, format, ...)					NAMESPACE_PSAPI::Logger::getInstance().log(NAMESPACE_PSAPI::Enum::Severity::Debug, task, format, __VA_ARGS__)
 
-#define PSAPI_SET_SEVERITY_INFO								NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Info);
-#define PSAPI_SET_SEVERITY_WARNING							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Warning);
-#define PSAPI_SET_SEVERITY_ERROR							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Error);
-#define PSAPI_SET_SEVERITY_DEBUG							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Debug);
-#define PSAPI_SET_SEVERITY_PROFILE							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Profile);
+#define PSAPI_SET_SEVERITY_INFO								NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Info)
+#define PSAPI_SET_SEVERITY_WARNING							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Warning)
+#define PSAPI_SET_SEVERITY_ERROR							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Error)
+#define PSAPI_SET_SEVERITY_DEBUG							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Debug)
+#define PSAPI_SET_SEVERITY_PROFILE							NAMESPACE_PSAPI::Logger::getInstance().setSeverity(NAMESPACE_PSAPI::Enum::Severity::Profile)
 
 
 PSAPI_NAMESPACE_BEGIN
 
 
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 namespace
 {
     std::string leftAlignString(const std::string str, int totalLength)
@@ -42,6 +44,8 @@ namespace
 }
 
 
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 namespace Enum
 {
     enum class Severity
@@ -55,10 +59,13 @@ namespace Enum
 }
 
 
+// Singleton logger instance to be used by calling getInstance() followed by the relevant function to be accessed
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
 class Logger {
 
 public:
-    // Function to get the logger instance
+    // Function to get the logger instance, there is only one per
     inline static Logger& getInstance() {
         static Logger instance; // This will be created only once
         return instance;

--- a/PhotoshopAPI/src/Util/Profiling/Memory/CompressionTracker.h
+++ b/PhotoshopAPI/src/Util/Profiling/Memory/CompressionTracker.h
@@ -52,8 +52,8 @@ public:
 
     void EndSession()
     {
-        PSAPI_LOG("CompressionTracker", "Total size compressed %" PRIu64 " Megabytes", m_CompressedSize / 1024 / 1024)
-        PSAPI_LOG("CompressionTracker", "Total size uncompressed %" PRIu64 " Megabytes", m_UncompressedSize / 1024 / 1024)
+        PSAPI_LOG_DEBUG("CompressionTracker", "Total size compressed %" PRIu64 " Megabytes", m_CompressedSize / 1024 / 1024);
+        PSAPI_LOG_DEBUG("CompressionTracker", "Total size uncompressed %" PRIu64 " Megabytes", m_UncompressedSize / 1024 / 1024);
         delete m_CurrentSession;
         m_CurrentSession = nullptr;
     }

--- a/PhotoshopAPI/src/Util/Struct/ByteStream.cpp
+++ b/PhotoshopAPI/src/Util/Struct/ByteStream.cpp
@@ -14,9 +14,7 @@ void ByteStream::setOffset(const uint64_t offset)
 {
 	if (offset > m_Size)
 	{
-		PSAPI_LOG_ERROR("ByteStream", "Trying to access illegal offset, maximum is %" PRIu64 " but got %" PRIu64 " instead",
-			m_Size,
-			offset)
+		PSAPI_LOG_ERROR("ByteStream", "Trying to access illegal offset, maximum is %" PRIu64 " but got %" PRIu64 " instead", m_Size, offset);
 	}
 	m_Offset = offset;
 }
@@ -29,9 +27,7 @@ void ByteStream::read(char* buffer, uint64_t size)
 	PROFILE_FUNCTION();
 	if (m_Offset + size > m_Size)
 	{
-		PSAPI_LOG_ERROR("ByteStream", "Trying to read too much data, maximum is %" PRIu64 " but got %" PRIu64 " instead",
-			m_Size,
-			m_Offset + size)
+		PSAPI_LOG_ERROR("ByteStream", "Trying to read too much data, maximum is %" PRIu64 " but got %" PRIu64 " instead", m_Size, m_Offset + size);			
 	}
 
 	// Use memcpy to copy data from m_Buffer to the provided buffer
@@ -49,17 +45,13 @@ void ByteStream::setOffsetAndRead(char* buffer, uint64_t offset, uint64_t size)
 	std::lock_guard<std::mutex> guard(m_Mutex);
 	if (offset > m_Size)
 	{
-		PSAPI_LOG_ERROR("ByteStream", "Trying to access illegal offset, maximum is %" PRIu64 " but got %" PRIu64 " instead",
-			m_Size,
-			offset)
+		PSAPI_LOG_ERROR("ByteStream", "Trying to access illegal offset, maximum is %" PRIu64 " but got %" PRIu64 " instead", m_Size, offset);
 	}
 	m_Offset = offset;
 
 	if (offset + size > m_Size)
 	{
-		PSAPI_LOG_ERROR("ByteStream", "Trying to read too much data, maximum is %" PRIu64 " but got %" PRIu64 " instead",
-			m_Size,
-			m_Offset + size)
+		PSAPI_LOG_ERROR("ByteStream", "Trying to read too much data, maximum is %" PRIu64 " but got %" PRIu64 " instead", m_Size, m_Offset + size);			
 	}
 
 	// Use memcpy to copy data from m_Buffer to the provided buffer

--- a/PhotoshopAPI/src/Util/Struct/File.cpp
+++ b/PhotoshopAPI/src/Util/Struct/File.cpp
@@ -12,7 +12,7 @@ void File::read(char* buffer, uint64_t size)
 	std::lock_guard<std::mutex> guard(m_Mutex);
 	if (m_Offset + size > m_Size) [[unlikely]]
 	{
-		PSAPI_LOG_ERROR("File", "Size %" PRIu64 " cannot be read from the file as it would exceed the file size", size)
+			PSAPI_LOG_ERROR("File", "Size %" PRIu64 " cannot be read from the file as it would exceed the file size", size);
 	}
 
 	m_Document.read(buffer, size);
@@ -42,7 +42,7 @@ void File::skip(int64_t size)
 	}
 	if (m_Offset + size > m_Size)
 	{
-		PSAPI_LOG_ERROR("File", "Size %" PRIu64 " cannot be read from the file as it would exceed the file size", size)
+		PSAPI_LOG_ERROR("File", "Size %" PRIu64 " cannot be read from the file as it would exceed the file size", size);
 	}
 	m_Document.ignore(size);
 	m_Offset += size;
@@ -86,7 +86,7 @@ void File::setOffsetAndRead(char* buffer, const uint64_t offset, const uint64_t 
 
 	if (m_Offset + size > m_Size)
 	{
-		PSAPI_LOG_ERROR("File", "Size %" PRIu64 " cannot be read from the file as it would exceed the file size", size)
+		PSAPI_LOG_ERROR("File", "Size %" PRIu64 " cannot be read from the file as it would exceed the file size", size);
 	}
 
 	m_Document.read(buffer, size);
@@ -109,7 +109,7 @@ File::File(const std::filesystem::path& file)
 	}
 	else
 	{
-		PSAPI_LOG("File", "Created file %s", file.string().c_str())
+		PSAPI_LOG("File", "Created file %s", file.string().c_str());
 		m_Document.open(file, std::ios::binary | std::fstream::in | std::fstream::out | std::fstream::trunc);
 	}
 

--- a/PhotoshopAPI/src/Util/Struct/ImageChannel.h
+++ b/PhotoshopAPI/src/Util/Struct/ImageChannel.h
@@ -33,12 +33,12 @@ struct BaseImageChannel
 		if (width > 300000u)
 		{
 			PSAPI_LOG_ERROR("ImageChannel", "Invalid width parsed to image channel. Photoshop channels can be 300,000 pixels wide, got %" PRIu32 " instead",
-				width)
+				width);
 		}
 		if (height > 300000u)
 		{
 			PSAPI_LOG_ERROR("ImageChannel", "Invalid height parsed to image channel. Photoshop channels can be 300,000 pixels high, got %" PRIu32 " instead",
-				height)
+				height);
 		}
 
 		m_Compression = compression;
@@ -128,7 +128,7 @@ struct ImageChannel : public BaseImageChannel
 			}
 			if (nchunks != nchunk + 1)
 			{
-				PSAPI_LOG_ERROR("ImageChannel", "Unexpected number of chunks")
+				PSAPI_LOG_ERROR("ImageChannel", "Unexpected number of chunks");
 			}
 		}
 

--- a/PhotoshopAPI/src/Util/Struct/PascalString.cpp
+++ b/PhotoshopAPI/src/Util/Struct/PascalString.cpp
@@ -31,7 +31,7 @@ uint64_t PascalString::calculateSize(std::shared_ptr<FileHeader> header /*= null
 	// We actually already take care of initializing the size in the constructor therefore it is valid
 	if (m_Size > std::numeric_limits<uint8_t>::max())
 	{
-		PSAPI_LOG_ERROR("PascalString", "Size of string exceeds the maximum for a uint8_t, expected a max of 255 but got %" PRIu64 " instead.", m_Size)
+		PSAPI_LOG_ERROR("PascalString", "Size of string exceeds the maximum for a uint8_t, expected a max of 255 but got %" PRIu64 " instead.", m_Size);
 	}
 	return m_Size;
 }
@@ -64,7 +64,7 @@ void PascalString::write(File& document, const uint8_t padding) const
 	// We must limit the string size like this as the length marker is only 1 byte and therefore has limited storage capabilities
 	if (m_String.size() >  254u - 254u % padding )
 	{
-		PSAPI_LOG_ERROR("PascalString", "A pascal string can have a maximum length of 254, got %u", m_String.size())
+		PSAPI_LOG_ERROR("PascalString", "A pascal string can have a maximum length of 254, got %u", m_String.size());
 	}
 	// The length marker only denotes the actual length of the data, not any padding
 	WriteBinaryData<uint8_t>(document, static_cast<uint8_t>(m_String.size()));

--- a/PhotoshopAPI/src/Util/Struct/ResourceBlock.cpp
+++ b/PhotoshopAPI/src/Util/Struct/ResourceBlock.cpp
@@ -40,7 +40,7 @@ void ResourceBlock::read(File& document)
 			signature.m_Representation[0],
 			signature.m_Representation[1],
 			signature.m_Representation[2],
-			signature.m_Representation[3])
+			signature.m_Representation[3]);
 	}
 	m_UniqueId = Enum::intToImageResource(ReadBinaryData<uint16_t>(document));
 	m_Name.read(document, 2u);

--- a/PhotoshopAPI/src/Util/Struct/Signature.cpp
+++ b/PhotoshopAPI/src/Util/Struct/Signature.cpp
@@ -26,11 +26,11 @@ Signature::Signature(const std::string val)
 {
     if (val.length() < 4)
     {
-        PSAPI_LOG_ERROR("Signature", "Signature cannot get initialized with less than 4 characters, got %s", val.c_str())
+        PSAPI_LOG_ERROR("Signature", "Signature cannot get initialized with less than 4 characters, got %s", val.c_str());
     }
     if (val.length() > 4)
     {
-        PSAPI_LOG_WARNING("Signature", "Signature struct has a length of 4, the last %i characters of %s will be cut off", val.length() - 4, val.c_str())
+        PSAPI_LOG_WARNING("Signature", "Signature struct has a length of 4, the last %i characters of %s will be cut off", val.length() - 4, val.c_str());
     }
 
     m_Value = 0;

--- a/PhotoshopAPI/src/Util/Struct/TaggedBlock.cpp
+++ b/PhotoshopAPI/src/Util/Struct/TaggedBlock.cpp
@@ -53,7 +53,7 @@ void TaggedBlock::write(File& document, const FileHeader& header, const uint16_t
 	std::optional<std::vector<std::string>> keyStr = Enum::getTaggedBlockKey<Enum::TaggedBlockKey, std::vector<std::string>>(m_Key);
 	if (!keyStr.has_value())
 	{
-		PSAPI_LOG_ERROR("TaggedBlock", "Was unable to extract a string from the tagged block key")
+		PSAPI_LOG_ERROR("TaggedBlock", "Was unable to extract a string from the tagged block key");
 	}
 	else
 	{
@@ -89,11 +89,11 @@ void LrSectionTaggedBlock::read(File& document, const FileHeader& header, const 
 	uint32_t type = ReadBinaryData<uint32_t>(document);
 	if (type < 0 || type > 3)
 	{
-		PSAPI_LOG_ERROR("TaggedBlock", "Layer Section Divider type has to be between 0 and 3, got %u instead", type)
+		PSAPI_LOG_ERROR("TaggedBlock", "Layer Section Divider type has to be between 0 and 3, got %u instead", type);
 	};
 	auto sectionDividerType = Enum::getSectionDivider<uint32_t, Enum::SectionDivider>(type);
 	if (!sectionDividerType.has_value())
-		PSAPI_LOG_ERROR("TaggedBlock", "Could not find Layer Section Divider type by value")
+		PSAPI_LOG_ERROR("TaggedBlock", "Could not find Layer Section Divider type by value");
 	m_Type = sectionDividerType.value();
 
 
@@ -104,7 +104,7 @@ void LrSectionTaggedBlock::read(File& document, const FileHeader& header, const 
 		if (sig != Signature("8BIM"))
 		{
 			PSAPI_LOG_ERROR("TaggedBlock", "Signature does not match '8BIM', got '%s' instead",
-				uint32ToString(sig.m_Value).c_str())
+				uint32ToString(sig.m_Value).c_str());
 		}
 
 		std::string blendModeStr = uint32ToString(ReadBinaryData<uint32_t>(document));
@@ -132,7 +132,7 @@ void LrSectionTaggedBlock::write(File& document, const FileHeader& header, const
 
 	auto sectionDividerType = Enum::getSectionDivider<Enum::SectionDivider, uint32_t>(m_Type);
 	if (!sectionDividerType.has_value())
-		PSAPI_LOG_ERROR("TaggedBlock", "Could not find Layer Section Divider type by value")
+		PSAPI_LOG_ERROR("TaggedBlock", "Could not find Layer Section Divider type by value");
 	WriteBinaryData<uint32_t>(document, sectionDividerType.value());
 	
 	// For some reason the blend mode has another 4 bytes for a 8BPS key
@@ -141,7 +141,7 @@ void LrSectionTaggedBlock::write(File& document, const FileHeader& header, const
 		WriteBinaryData<uint32_t>(document, Signature("8BIM").m_Value);
 		std::optional<std::string> blendModeStr = Enum::getBlendMode<Enum::BlendMode, std::string>(m_BlendMode.value());
 		if (!blendModeStr.has_value())
-			PSAPI_LOG_ERROR("LayerRecord", "Could not identify a blend mode string from the given key")
+			PSAPI_LOG_ERROR("LayerRecord", "Could not identify a blend mode string from the given key");
 		else 
 			WriteBinaryData<uint32_t>(document, Signature(blendModeStr.value()).m_Value);
 	}

--- a/PhotoshopAPI/src/Util/Struct/TaggedBlockStorage.cpp
+++ b/PhotoshopAPI/src/Util/Struct/TaggedBlockStorage.cpp
@@ -67,7 +67,7 @@ const std::shared_ptr<TaggedBlock> TaggedBlockStorage::readTaggedBlock(File& doc
 	if (signature != Signature("8BIM") && signature != Signature("8B64"))
 	{
 		PSAPI_LOG_ERROR("LayerRecord", "Signature does not match '8BIM' or '8B64', got '%s' instead",
-			uint32ToString(signature.m_Value).c_str())
+			uint32ToString(signature.m_Value).c_str());
 	}
 	std::string keyStr = uint32ToString(ReadBinaryData<uint32_t>(document));
 	std::optional<Enum::TaggedBlockKey> taggedBlock = Enum::getTaggedBlockKey<std::string, Enum::TaggedBlockKey>(keyStr);

--- a/PhotoshopTest/src/TestCompression/TestZipCompression.cpp
+++ b/PhotoshopTest/src/TestCompression/TestZipCompression.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Compress Flat Channel 16-bit")
 	std::vector<uint16_t> channel(width * height, (std::numeric_limits<uint16_t>::max)());
 	std::vector<uint16_t> dataExpected = channel;	// We construct a copy here as CompressZIP will invalidate the data
 
-	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<uint16_t>(channel, width, height);
+	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<uint16_t>(channel);
 	std::vector<uint16_t> uncompressedData = NAMESPACE_PSAPI::DecompressZIP<uint16_t>(compressedData, width, height);
 
 	CHECK(dataExpected == uncompressedData);
@@ -43,7 +43,7 @@ TEST_CASE("Compress Flat Channel 32-bit")
 	std::vector<float32_t> channel(width * height, 1.0f);
 	std::vector<float32_t> dataExpected = channel;	// We construct a copy here as CompressZIP will invalidate the data
 
-	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<float32_t>(channel, width, height);
+	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<float32_t>(channel);
 	std::vector<float32_t> uncompressedData = NAMESPACE_PSAPI::DecompressZIP<float32_t>(compressedData, width, height);
 
 	CHECK(dataExpected == uncompressedData);
@@ -62,7 +62,7 @@ TEST_CASE("Compress Large Flat Channel 16-bit")
 	std::vector<uint16_t> channel(width * height, (std::numeric_limits<uint16_t>::max)());
 	std::vector<uint16_t> dataExpected = channel;	// We construct a copy here as CompressZIP will invalidate the data
 
-	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<uint16_t>(channel, width, height);
+	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<uint16_t>(channel);
 	std::vector<uint16_t> uncompressedData = NAMESPACE_PSAPI::DecompressZIP<uint16_t>(compressedData, width, height);
 
 	CHECK(dataExpected == uncompressedData);
@@ -81,7 +81,7 @@ TEST_CASE("Compress Large Flat Channel 32-bit")
 	std::vector<float32_t> channel(width * height, 1.0f);
 	std::vector<float32_t> dataExpected = channel;	// We construct a copy here as CompressZIP will invalidate the data
 
-	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<float32_t>(channel, width, height);
+	std::vector<uint8_t> compressedData = NAMESPACE_PSAPI::CompressZIP<float32_t>(channel);
 	std::vector<float32_t> uncompressedData = NAMESPACE_PSAPI::DecompressZIP<float32_t>(compressedData, width, height);
 
 	CHECK(dataExpected == uncompressedData);

--- a/PhotoshopTest/src/TestCompression/Utility.cpp
+++ b/PhotoshopTest/src/TestCompression/Utility.cpp
@@ -129,7 +129,7 @@ void checkCompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, cons
 template <typename T>
 void checkCompressionFile(std::filesystem::path& inputPath)
 {
-	PSAPI_LOG_ERROR("CheckCompressionFile", "Unimplemented template type")
+	PSAPI_LOG_ERROR("CheckCompressionFile", "Unimplemented template type");
 }
 
 

--- a/PhotoshopTest/src/TestDecompression/Utility.cpp
+++ b/PhotoshopTest/src/TestDecompression/Utility.cpp
@@ -154,7 +154,7 @@ void checkDecompressionFileImpl(NAMESPACE_PSAPI::LayerInfo& layerInformation, co
 template <typename T>
 void checkDecompressionFile(std::filesystem::path& inputPath, const double zero_val, const double val_128, const double one_val, const double red_zero_val)
 {
-	PSAPI_LOG_ERROR("CheckCompressionFile", "Unimplemented template type")
+	PSAPI_LOG_ERROR("CheckCompressionFile", "Unimplemented template type");
 }
 
 

--- a/PhotoshopTest/src/main.cpp
+++ b/PhotoshopTest/src/main.cpp
@@ -72,7 +72,7 @@ void profile()
 		std::filesystem::path combined_path = currentDirectory;
 		combined_path += path;
 
-		PSAPI_LOG("Main", "Started Parsing of file %s", combined_path.string().c_str())
+		PSAPI_LOG_DEBUG("Main", "Started Parsing of file %s", combined_path.string().c_str());
 
 		NAMESPACE_PSAPI::File file(combined_path);
 		std::unique_ptr<NAMESPACE_PSAPI::PhotoshopFile> document = std::make_unique<NAMESPACE_PSAPI::PhotoshopFile>();


### PR DESCRIPTION
Change Logging macro signature to exclude semicolons requiring them to be added explicitly