### PR TITLE
[Performance] allow for parallelized ImageLayer creation

### DIFF
--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
@@ -31,6 +31,9 @@ struct LayerMask
 template <typename T>
 struct Layer
 {
+	/// Template type accessor which can be used using decltype(layer::value_type)
+	using value_type = T;
+
 	/// Layer Parameters for initialization of a generic layer type. It provides sensible defaults so only what is needed
 	/// needs to be overridden
 	struct Params


### PR DESCRIPTION
Allow us to parallelize the creation of our image layers as well as adding some template magic for specializing with execution policies in the case the user is already parallelizing it.