### PR TITLE
Automatically forward masks passed as channel to Layer<T>::m_LayerMask

### DIFF
--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/GroupLayer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/GroupLayer.h
@@ -202,35 +202,22 @@ struct GroupLayer : public Layer<T>
 	/// \brief Constructs a GroupLayer with the given layer parameters and collapse state.
 	/// \param layerParameters The parameters for the group layer.
 	/// \param isCollapsed Specifies whether the group layer is initially collapsed.
-	GroupLayer(Layer<T>::Params& layerParameters, bool isCollapsed = false)
+	GroupLayer(Layer<T>::Params& parameters, bool isCollapsed = false)
 	{
 		PROFILE_FUNCTION();
-		Layer<T>::m_LayerName = layerParameters.layerName;
-		Layer<T>::m_BlendMode = layerParameters.blendMode;
-		Layer<T>::m_Opacity = layerParameters.opacity;
-		Layer<T>::m_IsVisible = true;
-		Layer<T>::m_CenterX = layerParameters.posX;
-		Layer<T>::m_CenterY = layerParameters.posY;
-		Layer<T>::m_Width = layerParameters.width;
-		Layer<T>::m_Height = layerParameters.height;
+		Layer<T>::m_LayerName = parameters.layerName;
+		Layer<T>::m_BlendMode = parameters.blendMode;
+		Layer<T>::m_Opacity = parameters.opacity;
+		Layer<T>::m_IsVisible = parameters.isVisible;
+		Layer<T>::m_CenterX = parameters.posX;
+		Layer<T>::m_CenterY = parameters.posY;
+		Layer<T>::m_Width = parameters.width;
+		Layer<T>::m_Height = parameters.height;
 
+		m_isCollapsed = isCollapsed;
 
 		// Set the layer mask if present
-		if (layerParameters.layerMask.has_value())
-		{
-			LayerMask mask{};
-			Enum::ChannelIDInfo info{ .id = Enum::ChannelID::UserSuppliedLayerMask, .index = -2 };
-			std::unique_ptr<ImageChannel> maskChannel = std::make_unique<ImageChannel>(
-				layerParameters.compression, 
-				layerParameters.layerMask.value(), 
-				info, 
-				layerParameters.width, 
-				layerParameters.height, 
-				static_cast<float>(layerParameters.posX), 
-				static_cast<float>(layerParameters.posY));
-			mask.maskData = std::move(maskChannel);
-			Layer<T>::m_LayerMask = std::move(mask);
-		}
+		Layer<T>::parseLayerMask(parameters);
 	}
 
 

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/Layer.h
@@ -60,6 +60,8 @@ struct Layer
 		Enum::Compression compression = Enum::Compression::ZipPrediction; 
 		// The Layers color mode, currently only RGB is supported
 		Enum::ColorMode colorMode = Enum::ColorMode::RGB;
+		// Whether or not the layer is visible
+		bool isVisible = true;
 	};
 
 	std::string m_LayerName;
@@ -84,6 +86,26 @@ struct Layer
 	float m_CenterY;
 
 protected:
+
+	/// Parse the layer mask passed as part of the parameters into m_LayerMask
+	void parseLayerMask(Params& parameters)
+	{
+		if (parameters.layerMask)
+		{
+			LayerMask mask{};
+			Enum::ChannelIDInfo info{ .id = Enum::ChannelID::UserSuppliedLayerMask, .index = -2 };
+			mask.maskData = std::make_unique<ImageChannel>(
+				parameters.compression,
+				parameters.layerMask.value(),
+				info,
+				parameters.width,
+				parameters.height,
+				static_cast<float>(parameters.posX),
+				static_cast<float>(parameters.posY)
+			);
+			Layer<T>::m_LayerMask = std::move(mask);
+		}
+	}
 
 	/// \brief Generates the LayerMaskData struct from the layer mask (if provided).
 	///

--- a/PhotoshopTest/src/TestImageLayer/TestImageLayer.cpp
+++ b/PhotoshopTest/src/TestImageLayer/TestImageLayer.cpp
@@ -1,0 +1,140 @@
+#include "doctest.h"
+
+#include "../DetectArmMac.h"
+
+#include "Macros.h"
+#include "LayeredFile/LayeredFile.h"
+#include "LayeredFile/LayerTypes/ImageLayer.h"
+
+#include <string>
+#include <vector>
+
+
+
+TEST_CASE("Construct ImageLayer with int16_t ctor")
+{
+	using namespace NAMESPACE_PSAPI;
+	using type = bpp16_t;
+	constexpr int32_t width = 64;
+	constexpr int32_t height = 64;
+	constexpr int32_t size = width * height;
+
+	std::unordered_map<int16_t, std::vector<type>> data =
+	{
+		{0, std::vector<type>(size)},
+		{1, std::vector<type>(size)},
+		{2, std::vector<type>(size)},
+	};
+	auto params = typename Layer<type>::Params
+	{
+		.layerName = "Layer",
+		.width = width,
+		.height = height,
+	};
+
+	auto layer = std::make_shared<ImageLayer<type>>(std::move(data), params);
+
+	CHECK(layer->m_Width == width);
+	CHECK(layer->m_Height == height);
+	CHECK(layer->m_LayerName == "Layer");
+	CHECK(layer->m_ImageData.size() == data.size());
+}
+
+
+TEST_CASE("Construct ImageLayer with mask as part of image data")
+{
+	using namespace NAMESPACE_PSAPI;
+	using type = bpp16_t;
+	constexpr int32_t width = 64;
+	constexpr int32_t height = 64;
+	constexpr int32_t size = width * height;
+
+	std::unordered_map<int16_t, std::vector<type>> data =
+	{
+		{-2, std::vector<type>(size)},
+		{0, std::vector<type>(size)},
+		{1, std::vector<type>(size)},
+		{2, std::vector<type>(size)},
+	};
+	auto params = typename Layer<type>::Params
+	{
+		.layerName = "Layer",
+		.width = width,
+		.height = height,
+	};
+
+	auto layer = std::make_shared<ImageLayer<type>>(std::move(data), params);
+
+	CHECK(layer->m_Width == width);
+	CHECK(layer->m_Height == height);
+	CHECK(layer->m_LayerName == "Layer");
+	CHECK(layer->m_LayerMask);
+}
+
+
+TEST_CASE("Construct ImageLayer with explicit mask")
+{
+	using namespace NAMESPACE_PSAPI;
+	using type = bpp16_t;
+	constexpr int32_t width = 64;
+	constexpr int32_t height = 64;
+	constexpr int32_t size = width * height;
+
+	std::unordered_map<int16_t, std::vector<type>> data =
+	{
+		{0, std::vector<type>(size)},
+		{1, std::vector<type>(size)},
+		{2, std::vector<type>(size)},
+	};
+	auto params = typename Layer<type>::Params
+	{
+		.layerMask = std::vector<type>(size),
+		.layerName = "Layer",
+		.width = width,
+		.height = height,
+	};
+
+	auto layer = std::make_shared<ImageLayer<type>>(std::move(data), params);
+
+	CHECK(layer->m_Width == width);
+	CHECK(layer->m_Height == height);
+	CHECK(layer->m_LayerName == "Layer");
+	CHECK(layer->m_LayerMask);
+}
+
+
+#ifndef ARM_MAC_ARCH
+TEST_CASE("Construct ImageLayer with both mask as part of imagedata and through layer parameters"
+	* doctest::no_breaks(true)
+	* doctest::no_output(true)
+	* doctest::should_fail(true))
+{
+	using namespace NAMESPACE_PSAPI;
+	using type = bpp16_t;
+	constexpr int32_t width = 64;
+	constexpr int32_t height = 64;
+	constexpr int32_t size = width * height;
+
+	std::unordered_map<int16_t, std::vector<type>> data =
+	{
+		{-2, std::vector<type>(size)},
+		{0, std::vector<type>(size)},
+		{1, std::vector<type>(size)},
+		{2, std::vector<type>(size)},
+	};
+	auto params = typename Layer<type>::Params
+	{
+		.layerMask = std::vector<type>(size),
+		.layerName = "Layer",
+		.width = width,
+		.height = height,
+	};
+
+	auto layer = std::make_shared<ImageLayer<type>>(std::move(data), params);
+
+	CHECK(layer->m_Width == width);
+	CHECK(layer->m_Height == height);
+	CHECK(layer->m_LayerName == "Layer");
+	CHECK(layer->m_LayerMask);
+}
+#endif

--- a/python/src/DeclareGroupLayer.h
+++ b/python/src/DeclareGroupLayer.h
@@ -39,7 +39,7 @@ std::shared_ptr<GroupLayer<T>> createGroupLayer(
     {
         throw py::value_error("layer_name parameter cannot exceed a length of 255");
     }
-    if (layer_mask.has_value())
+    if (layer_mask)
     {
         if (static_cast<uint64_t>(width) * height != layer_mask.value().size())
         {


### PR DESCRIPTION
Additionally, we fixed the old bug #65 which was caused by how we calculated channel counts and a bug where a groups' isCollapsed parameter was ignored