### PR TITLE
Bug fix misc smart object read errors

### DIFF
--- a/PhotoshopAPI/src/Core/Struct/DescriptorStructure.h
+++ b/PhotoshopAPI/src/Core/Struct/DescriptorStructure.h
@@ -465,6 +465,30 @@ namespace Descriptors
 			throw std::out_of_range(fmt::format("Key {} not found in descriptor.", key));
 		}
 
+		/// Access one of the sub-elements as the given type, performing bounds checking and returning
+		/// `default_val` if the key is not found, if the requested type is incorrect this will still throw
+		/// std::invalid_argument
+		/// 
+		/// \param key The key to search for
+		/// \param default_val The default value if the key cannot be found
+		/// \tparam T The type to retrieve it as
+		/// 
+		/// \returns A copy of the descriptor
+		template <typename T>
+			requires std::is_same_v<T, bool> || std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t> || std::is_same_v<T, double> || std::is_same_v<T, UnicodeString>
+		T get(const std::string key, T default_val)
+		{
+			try 
+			{
+				return this->at<T>(key);
+			}
+			catch ([[maybe_unused]] std::out_of_range& e)
+			{
+				return default_val;
+			}
+			return default_val;
+		}
+
 		/// Insert the given key-value pair into the Descriptor. If the key is already present the new item is ignored
 		void insert(std::pair<std::string, std::unique_ptr<DescriptorBase>> item) noexcept;
 		/// Insert the given key-value pair into the Descriptor. If the key is already present the new item is ignored

--- a/PhotoshopAPI/src/Core/TaggedBlocks/LinkedLayerTaggedBlock.cpp
+++ b/PhotoshopAPI/src/Core/TaggedBlocks/LinkedLayerTaggedBlock.cpp
@@ -153,7 +153,7 @@ void LinkedLayerItem::Data::read(File& document)
 		m_AssetIsLocked = ReadBinaryData<bool>(document);
 	}
 
-	if (m_Version == 2)
+	if (m_Version == 2 && m_Type == Type::External)
 	{
 		m_RawFileBytes = ReadBinaryArray<uint8_t>(document, dataSize);
 	}

--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/SmartObjectLayer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/SmartObjectLayer.h
@@ -1151,12 +1151,13 @@ private:
 		m_Hash = descriptor->at<UnicodeString>("Idnt").string();	// The identifier that maps back to the LinkedLayer
 
 		// These we all ignore for the time being, we store them locally and just rewrite them back out later
-		// This isn't necessarily in order
+		// This isn't necessarily in order. Some of these aren't available in all versions but we don't track 
+		// that either since we write out descriptors valid for the latest version.
 		{
 			_m_LayerHash = descriptor->at<UnicodeString>("placed").getString();
 			_m_PageNum = descriptor->at<int32_t>("PgNm");
 			_m_NumPages = descriptor->at<int32_t>("totalPages");
-			_m_Crop = descriptor->at<int32_t>("Crop");
+			_m_Crop = descriptor->get<int32_t>("Crop", 1u);
 
 			const auto _frame_step = descriptor->at<Descriptors::Descriptor>("frameStep");
 			_m_FrameStepNumerator = _frame_step->at<int32_t>("numerator");
@@ -1171,11 +1172,16 @@ private:
 
 			_m_Type = descriptor->at<int32_t>("Type");
 
-			_m_Comp = descriptor->at<int32_t>("comp");
+			_m_Comp = descriptor->get<int32_t>("comp", -1);
 
-			const auto _comp_info = descriptor->at<Descriptors::Descriptor>("compInfo");
-			_m_CompInfoID = _comp_info->at<int32_t>("compID");
-			_m_CompInfoOriginalID = _comp_info->at<int32_t>("originalCompID");
+			// When parsing older-style descriptors these may not always be present, in that case the defaults are
+			// fine.
+			if (descriptor->contains("compInfo"))
+			{
+				const auto _comp_info = descriptor->at<Descriptors::Descriptor>("compInfo");
+				_m_CompInfoID = _comp_info->at<int32_t>("compID");
+				_m_CompInfoOriginalID = _comp_info->at<int32_t>("originalCompID");
+			}
 		}
 
 		const auto size = descriptor->at<Descriptors::Descriptor>("Sz  ");		// The spaces are not a mistake

--- a/PhotoshopAPI/src/LayeredFile/LinkedData/PsdPsbReader.h
+++ b/PhotoshopAPI/src/LayeredFile/LinkedData/PsdPsbReader.h
@@ -98,9 +98,9 @@ namespace detail
 			}
 			if (num_channels != 3 && num_channels != 4)
 			{
-				PSAPI_LOG_ERROR(
-					"psd_psb_reader", "Invalid number of channels received for the global image data, only 3 or 4 channels"
-					" are supported (RGB or RGBA), instead got %zu", num_channels
+				PSAPI_LOG_WARNING(
+					"psd_psb_reader", "Non-standard number of channels received for the global image data, only 3 or 4 channels"
+					" are supported (RGB or RGBA), instead got %zu. Will not parse the other channels.", num_channels
 				);
 			}
 
@@ -110,6 +110,9 @@ namespace detail
 				Enum::ChannelIDInfo{Enum::ChannelID::Blue,  static_cast<int16_t>(2)},
 				Enum::ChannelIDInfo{Enum::ChannelID::Alpha, static_cast<int16_t>(-1)},
 			};
+
+			// We only support at most 4 channels to read.
+			num_channels = std::min(num_channels, size_t{ 4u });
 			
 			for (auto idx : std::views::iota(static_cast<size_t>(0), num_channels))
 			{

--- a/PhotoshopTest/src/TestSmartObjects/TestSmartObjectLayer.cpp
+++ b/PhotoshopTest/src/TestSmartObjects/TestSmartObjectLayer.cpp
@@ -6,6 +6,7 @@
 #include "Core/Warp/SmartObjectWarp.h"
 
 #include "../DetectArmMac.h"
+#include "../TestMacros.h"
 
 #include "Core/Render/ImageBuffer.h"
 #include "Core/Render/Composite.h"
@@ -90,6 +91,39 @@ TEST_CASE("modify warp and get dimensions")
 	// we expect the same result.
 	CHECK(layer->width() == doctest::Approx(200.0f));
 	CHECK(layer->height() == doctest::Approx(108.0f));
+}
+
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------------
+TEST_CASE("Replace image multiple times same result")
+{
+	// Test that our file replace operations can be done as many times as wanted without the image changing.
+	// It should be entirely deterministic
+	using namespace NAMESPACE_PSAPI;
+	using bpp_type = uint8_t;
+
+	auto file = LayeredFile<bpp_type>::read(std::filesystem::current_path() / "documents/SmartObjects/smart_objects_transformed.psd");
+
+	auto smart_object_layer = find_layer_as<bpp_type, SmartObjectLayer>("simple_warp/bbox_change_perspective_warp", file);
+
+	smart_object_layer->replace("documents/SmartObjects/reference/control.png");
+	auto ref = smart_object_layer->get_image_data();
+
+	// Repeat this 10 times in a row
+	for (int i = 0; i < 10; ++i)
+	{
+		smart_object_layer->replace("documents/SmartObjects/reference/control.png");
+		auto image_data = smart_object_layer->get_image_data();
+
+		REQUIRE(ref.size() == image_data.size());
+
+		for (const auto [key, value] : ref)
+		{
+			CHECK_VEC_VERBOSE(ref[key], image_data[key]);
+		}
+	}
 }
 
 


### PR DESCRIPTION
This MR fixes a bunch of miscellaneous read errors when reading alternative versions of the descriptors by Photoshop 