### PR TITLE
CI: replace run-vcpkg in favor of vcpkg-cache as previous action wasn't working anymore

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -35,6 +35,10 @@ jobs:
 
 
   build_wheels:
+    permissions:
+      actions: read
+      contents: read
+
     name: Wheels on ${{ matrix.os_dist.os }}-${{ matrix.os_dist.dist }}
     runs-on: ${{ matrix.os_dist.os }}
     strategy:
@@ -71,19 +75,21 @@ jobs:
     - name: Setup macos dependencies
       if: matrix.os_dist.os == 'macos-latest'
       run: |
-          brew install ninja
           brew install autoconf
           brew install libtool
           brew install automake
       
-
-    - name: Initialize vcpkg
-      uses: lukka/run-vcpkg@v11
+    - name: Restore vcpkg cache
+      id: vcpkg-cache
+      uses: TAServers/vcpkg-cache@v3
       with:
-        vcpkgDirectory: '${{ github.workspace }}/thirdparty/vcpkg'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prefix: vcpkg-wheels/
 
     - uses: pypa/cibuildwheel@v2.23.1
       env:
+        VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+        VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         CC: gcc-13
         CXX: g++-13
         # The rest of the cibuildhweel related commands can be found on the pyproject.toml

--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -17,6 +17,10 @@ env:
 
 jobs:
   build:
+    permissions:
+      actions: read
+      contents: read
+
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -58,13 +62,17 @@ jobs:
           brew install libtool
           brew install automake
 
-    - name: Initialize vcpkg
-      uses: lukka/run-vcpkg@v11
+    - name: Restore vcpkg cache
+      id: vcpkg-cache
+      uses: TAServers/vcpkg-cache@v3
       with:
-        vcpkgDirectory: '${{ github.workspace }}/thirdparty/vcpkg'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prefix: vcpkg-build/
 
     - name: Configure CMake ${{ matrix.os }}-${{ matrix.compilercxx }}
       env:
+        VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+        VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilercxx }}
       run: |

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -17,6 +17,10 @@ env:
 
 jobs:
   test:
+    permissions:
+      actions: read
+      contents: read
+
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -66,13 +70,17 @@ jobs:
           brew install libtool
           brew install automake
 
-    - name: Initialize vcpkg
-      uses: lukka/run-vcpkg@v11
+    - name: Restore vcpkg cache
+      id: vcpkg-cache
+      uses: TAServers/vcpkg-cache@v3
       with:
-        vcpkgDirectory: '${{ github.workspace }}/thirdparty/vcpkg'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prefix: vcpkg-test/
   
     - name: Configure CMake ${{ matrix.os }}-${{ matrix.compilercxx }}
       env:
+        VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+        VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilercxx }}
         CFLAGS: ${{ matrix.cflags }}

--- a/.github/workflows/cmake-valgrind.yml
+++ b/.github/workflows/cmake-valgrind.yml
@@ -17,6 +17,10 @@ env:
 
 jobs:
   valgrind:
+    permissions:
+      actions: read
+      contents: read
+
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -37,13 +41,17 @@ jobs:
         submodules: 'recursive'
         fetch-depth: 0
 
-    - name: Load or restore vcpkg libraries
-      uses: lukka/run-vcpkg@v11
+    - name: Restore vcpkg cache
+      id: vcpkg-cache
+      uses: TAServers/vcpkg-cache@v3
       with:
-        vcpkgDirectory: '${{ github.workspace }}/thirdparty/vcpkg'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prefix: vcpkg-valgrind/
 
     - name: Configure CMake ${{ matrix.os }}-${{ matrix.compilercxx }}
       env:
+        VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+        VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compilercxx }}
         CFLAGS: ${{ matrix.cflags }}


### PR DESCRIPTION
It seems that vcpkg/github changed something in their internal tooling/cache action which make the `run-vcpkg` action not work anymore. 

This MR replaces it with `vcpkg-cache` as it was tested on another project and seems to work unlike `run-vcpkg`. This should allow us to drastically lower our build times again.