### PR TITLE
fix smart object transformations not being re-evaluated post-replace #162

### DIFF
--- a/PhotoshopAPI/src/LayeredFile/LayerTypes/SmartObjectLayer.h
+++ b/PhotoshopAPI/src/LayeredFile/LayerTypes/SmartObjectLayer.h
@@ -215,6 +215,8 @@ public:
 	void warp(SmartObject::Warp _warp) 
 	{ 
 		m_SmartObjectWarp = std::move(_warp);
+		invalidate_cache();
+		invalidate_mesh_cache();
 		evaluate_transforms();
 	}
 
@@ -260,6 +262,7 @@ public:
 		m_SmartObjectWarp.points(pts);
 		invalidate_cache();
 		invalidate_mesh_cache();
+		evaluate_transforms();
 	}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: BSD-3-Clause",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">= 3.8"


### PR DESCRIPTION
We weren't re-evaluating the image data post-replace which especially caused issues with images that don't fully fill the bounding box assigned by the warp